### PR TITLE
feat(19) : 결제 부분 검증 로직 추가 및 상태 변경 

### DIFF
--- a/src/main/java/com/deal4u/fourplease/FourPleaseBeApplication.java
+++ b/src/main/java/com/deal4u/fourplease/FourPleaseBeApplication.java
@@ -3,10 +3,11 @@ package com.deal4u.fourplease;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-
-@EnableFeignClients(basePackages = "com.deal4u.fourplease.domain.payment")
+@EnableScheduling
 @SpringBootApplication
+@EnableFeignClients(basePackages = "com.deal4u.fourplease.domain.payment")
 public class FourPleaseBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -1,6 +1,7 @@
 package com.deal4u.fourplease.domain.auction.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import java.math.BigDecimal;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,15 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "AND a.deleted = false "
             + "AND a.status = 'OPEN'")
     Optional<Auction> findByAuctionIdAndDeletedFalseAndStatusOpen(Long auctionId);
+
+
+    @Query("SELECT a "
+            + "FROM Auction a "
+            + "WHERE a.auctionId = :auctionId "
+            + "AND a.deleted = false "
+            + "AND a.status = 'CLOSED'")
+    Optional<Auction> findByAuctionIdAndDeletedFalseAndStatusClosed(Long auctionId);
+
+    @Query("SELECT MAX(b.price) FROM Bid b WHERE b.auction.auctionId = :auctionId AND b.deleted = false")
+    Optional<BigDecimal> findMaxBidPriceByAuctionId(Long auctionId);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -1,7 +1,6 @@
 package com.deal4u.fourplease.domain.auction.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
-import java.math.BigDecimal;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,9 +8,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
-    @Query("select a from Auction a join fetch a.product where a.auctionId = :auctionId")
+    @Query("SELECT a "
+            + "FROM Auction a "
+            + "JOIN FETCH a.product "
+            + "WHERE a.auctionId = :auctionId")
     Optional<Auction> findByIdWithProduct(@Param("auctionId") Long auctionId);
-
 
     @Query("SELECT a "
             + "FROM Auction a "
@@ -20,14 +21,10 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "AND a.status = 'OPEN'")
     Optional<Auction> findByAuctionIdAndDeletedFalseAndStatusOpen(Long auctionId);
 
-
     @Query("SELECT a "
             + "FROM Auction a "
             + "WHERE a.auctionId = :auctionId "
             + "AND a.deleted = false "
             + "AND a.status = 'CLOSED'")
     Optional<Auction> findByAuctionIdAndDeletedFalseAndStatusClosed(Long auctionId);
-
-    @Query("SELECT MAX(b.price) FROM Bid b WHERE b.auction.auctionId = :auctionId AND b.deleted = false")
-    Optional<BigDecimal> findMaxBidPriceByAuctionId(Long auctionId);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/repository/BidRepository.java
@@ -19,28 +19,26 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
     Optional<Bid> findTopByAuctionAndBidderOrderByPriceDesc(Auction auction, Bidder bidder);
 
-    @Query("select b.price from Bid b where b.deleted = false "
-            + "AND b.auction.auctionId = :auctionId order by b.price desc")
+    @Query("SELECT b.price "
+            + "FROM Bid b "
+            + "WHERE b.deleted = false "
+            + "AND b.auction.auctionId = :auctionId "
+            + "ORDER BY b.price DESC")
     List<Long> findPricesByAuctionIdOrderByPriceDesc(@Param("auctionId") Long auctionId);
 
-    @Query("SELECT b FROM Bid b "
+    @Query("SELECT b "
+            + "FROM Bid b "
             + "WHERE b.auction.auctionId = :auctionId "
             + "AND b.bidder.member = :member "
             + "AND b.isSuccessfulBidder = true")
     Optional<Bid> findSuccessFulBid(@Param("auctionId") Long auctionId,
                                     @Param("member") Member member);
 
-    @Query("SELECT MAX(b.price) FROM Bid b WHERE b.auction.auctionId = :auctionId AND b.deleted = false")
+    @Query("SELECT MAX(b.price) "
+            + "FROM Bid b "
+            + "WHERE b.auction.auctionId = :auctionId "
+            + "AND b.deleted = false")
     Optional<BigDecimal> findMaxBidPriceByAuctionId(Long auctionId);
-
-    @Query("SELECT b FROM Bid b " +
-            "JOIN FETCH b.auction " +
-            "WHERE b.auction.auctionId = :auctionId " +
-            "AND b.deleted = false " +
-            "AND b.isSuccessfulBidder = false " +
-            "ORDER BY b.price DESC, b.bidTime ASC")
-    Optional<Bid> findSecondHighestBidderByAuctionId(@Param("auctionId") Long auctionId);
-
 
     Optional<Bid> findByBidIdAndBidder(Long bidId, Bidder bidder);
 

--- a/src/main/java/com/deal4u/fourplease/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/repository/BidRepository.java
@@ -4,6 +4,7 @@ import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.entity.Bid;
 import com.deal4u.fourplease.domain.bid.entity.Bidder;
 import com.deal4u.fourplease.domain.member.entity.Member;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -28,6 +29,17 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
             + "AND b.isSuccessfulBidder = true")
     Optional<Bid> findSuccessFulBid(@Param("auctionId") Long auctionId,
                                     @Param("member") Member member);
+
+    @Query("SELECT MAX(b.price) FROM Bid b WHERE b.auction.auctionId = :auctionId AND b.deleted = false")
+    Optional<BigDecimal> findMaxBidPriceByAuctionId(Long auctionId);
+
+    @Query("SELECT b FROM Bid b " +
+            "JOIN FETCH b.auction " +
+            "WHERE b.auction.auctionId = :auctionId " +
+            "AND b.deleted = false " +
+            "AND b.isSuccessfulBidder = false " +
+            "ORDER BY b.price DESC, b.bidTime ASC")
+    Optional<Bid> findSecondHighestBidderByAuctionId(@Param("auctionId") Long auctionId);
 
 
     Optional<Bid> findByBidIdAndBidder(Long bidId, Bidder bidder);

--- a/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
@@ -141,10 +141,10 @@ public class BidService {
         return PageResponse.fromPage(bidResponsePage);
     }
 
+
     private Bidder getBidder(long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(ErrorCode.MEMBER_NOT_FOUND::toException);
         return Bidder.createBidder(member);
     }
-
 }

--- a/src/main/java/com/deal4u/fourplease/domain/order/entity/Order.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/entity/Order.java
@@ -63,6 +63,10 @@ public class Order extends BaseDateEntity {
         this.receiver = orderUpdateRequest.receiver();
     }
 
+    public void success() {
+        this.orderStatus = OrderStatus.SUCCESS;
+    }
+
     public void failed() {
         this.orderStatus = OrderStatus.FAILED;
     }

--- a/src/main/java/com/deal4u/fourplease/domain/order/entity/Order.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/entity/Order.java
@@ -7,6 +7,8 @@ import com.deal4u.fourplease.domain.order.dto.OrderUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -47,11 +49,21 @@ public class Order extends BaseDateEntity {
     private String content;
     private String receiver;
 
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @Enumerated(EnumType.STRING)
+    private OrderType orderType;
+
     public void updateOrder(OrderUpdateRequest orderUpdateRequest) {
         this.address = new Address(orderUpdateRequest.address(), orderUpdateRequest.addressDetail(),
                 orderUpdateRequest.zipCode());
         this.phone = orderUpdateRequest.phone();
         this.content = orderUpdateRequest.content();
         this.receiver = orderUpdateRequest.receiver();
+    }
+
+    public void failed() {
+        this.orderStatus = OrderStatus.FAILED;
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/entity/OrderStatus.java
@@ -2,5 +2,6 @@ package com.deal4u.fourplease.domain.order.entity;
 
 public enum OrderStatus {
     SUCCESS,
-    FAILED,
+    PENDING,
+    FAILED
 }

--- a/src/main/java/com/deal4u/fourplease/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/entity/OrderStatus.java
@@ -1,5 +1,6 @@
 package com.deal4u.fourplease.domain.order.entity;
 
-public enum OrderType {
-    BUY_NOW, AWARD
+public enum OrderStatus {
+    SUCCESS,
+    FAILED,
 }

--- a/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
@@ -9,7 +9,6 @@ import static com.deal4u.fourplease.global.exception.ErrorCode.ORDER_NOT_FOUND;
 import static com.deal4u.fourplease.global.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
-import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.entity.Bid;
 import com.deal4u.fourplease.domain.bid.repository.BidRepository;
@@ -73,20 +72,8 @@ public class OrderService {
     }
 
     @Transactional
-    public void closeAuction(Auction auction) {
-        if (auction.getStatus().equals(AuctionStatus.OPEN)) {
-            auction.close();
-        }
-    }
-
-    @Transactional
     public void faliedOrder(Order order) {
         order.failed();
-    }
-
-    @Transactional
-    public void succesOrder(Order order) {
-        order.success();
     }
 
     private OrderType validateOrderType(String orderType) {

--- a/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
@@ -41,10 +41,8 @@ public class OrderService {
     public String saveOrder(Long auctionId, String orderType,
                             OrderCreateRequest orderCreateRequest) {
 
-        // String 값을 OrderType Enum으로 변환 및 검증
         OrderType orderTypeEnum = validateType(orderType);
 
-        // 나머지 로직
         Long memberId = 1L;
         Member member = getMemberOrThrow(memberId);
         Auction auction = getAuctionOrThrow(auctionId);

--- a/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
@@ -9,6 +9,7 @@ import static com.deal4u.fourplease.global.exception.ErrorCode.ORDER_NOT_FOUND;
 import static com.deal4u.fourplease.global.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.entity.Bid;
 import com.deal4u.fourplease.domain.bid.repository.BidRepository;
@@ -73,7 +74,19 @@ public class OrderService {
 
     @Transactional
     public void closeAuction(Auction auction) {
-        auction.close();
+        if (auction.getStatus().equals(AuctionStatus.OPEN)) {
+            auction.close();
+        }
+    }
+
+    @Transactional
+    public void faliedOrder(Order order) {
+        order.failed();
+    }
+
+    @Transactional
+    public void succesOrder(Order order) {
+        order.success();
     }
 
     private OrderType validateOrderType(String orderType) {
@@ -112,7 +125,7 @@ public class OrderService {
                 .auction(auction)
                 .orderer(orderer)
                 .price(orderPrice)
-                .orderStatus(OrderStatus.SUCCESS)
+                .orderStatus(OrderStatus.PENDING)
                 .orderType(orderType)
                 .build();
     }

--- a/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/order/service/OrderService.java
@@ -132,9 +132,9 @@ public class OrderService {
 
     private Auction getAuctionForOrder(Long auctionId, OrderType orderTypeEnum) {
         if (OrderType.BUY_NOW.equals(orderTypeEnum)) {
-            return getOPENAuctionOrThrow(auctionId);
+            return getOpenAuctionOrThrow(auctionId);
         } else if (OrderType.AWARD.equals(orderTypeEnum)) {
-            return getCLOSEDAuctionOrThrow(auctionId);
+            return getClosedAuctionOrThrow(auctionId);
         }
         throw INVALID_ORDER_TYPE.toException();
     }
@@ -145,12 +145,12 @@ public class OrderService {
                 .orElseThrow(INVALID_AUCTION_BIDDER::toException);
     }
 
-    private Auction getOPENAuctionOrThrow(Long auctionId) {
+    private Auction getOpenAuctionOrThrow(Long auctionId) {
         return auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(auctionId)
                 .orElseThrow(AUCTION_NOT_FOUND::toException);
     }
 
-    private Auction getCLOSEDAuctionOrThrow(Long auctionId) {
+    private Auction getClosedAuctionOrThrow(Long auctionId) {
         return auctionRepository.findByAuctionIdAndDeletedFalseAndStatusClosed(auctionId)
                 .orElseThrow(AUCTION_NOT_FOUND::toException);
     }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/entity/Payment.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/entity/Payment.java
@@ -40,4 +40,8 @@ public class Payment extends BaseDateEntity {
 
     @Embedded
     private OrderId orderId;
+
+    public void statusFailed() {
+        this.status = PaymentStatus.FAILED;
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/entity/Payment.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/entity/Payment.java
@@ -44,4 +44,8 @@ public class Payment extends BaseDateEntity {
     public void statusFailed() {
         this.status = PaymentStatus.FAILED;
     }
+
+    public void statusSuccess() {
+        this.status = PaymentStatus.SUCCESS;
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/entity/PaymentStatus.java
@@ -1,5 +1,5 @@
 package com.deal4u.fourplease.domain.payment.entity;
 
 public enum PaymentStatus {
-    SUCCESS, FAILED
+    SUCCESS, PENDING, FAILED
 }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/mapper/PaymentMapper.java
@@ -18,7 +18,7 @@ public class PaymentMapper {
                                     TossPaymentConfirmResponse response) {
         return Payment.builder()
                 .amount(BigDecimal.valueOf(tossPaymentConfirmRequest.amount()))
-                .status(PaymentStatus.SUCCESS)
+                .status(PaymentStatus.PENDING)
                 .paymentKey(response.paymentKey())
                 .orderId(order.getOrderId())
                 .build();

--- a/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentService.java
@@ -58,12 +58,10 @@ public class PaymentService {
 
             validatePaymentSuccessOrToFailed(response, payment, order);
 
-            paymentTransactionService.paymentStatusSuccess(payment);
+            paymentTransactionService.paymentStatusSuccess(payment, order, auction);
 
 
         } finally {
-            orderService.succesOrder(order);
-            orderService.closeAuction(auction);
             lock.unlock();
         }
     }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentService.java
@@ -1,15 +1,20 @@
 package com.deal4u.fourplease.domain.payment.service;
 
 import static com.deal4u.fourplease.global.exception.ErrorCode.INVALID_PAYMENT_AMOUNT;
+import static com.deal4u.fourplease.global.exception.ErrorCode.INVALID_PRICE_NOT_UPPER;
 import static com.deal4u.fourplease.global.exception.ErrorCode.PAYMENT_CONFIRMATION_FAILED;
 import static com.deal4u.fourplease.global.exception.ErrorCode.PAYMENT_ERROR;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.bid.repository.BidRepository;
 import com.deal4u.fourplease.domain.order.entity.Order;
 import com.deal4u.fourplease.domain.order.entity.OrderId;
+import com.deal4u.fourplease.domain.order.entity.OrderType;
+import com.deal4u.fourplease.domain.order.service.OrderService;
 import com.deal4u.fourplease.domain.payment.config.TossApiClient;
 import com.deal4u.fourplease.domain.payment.dto.TossPaymentConfirmRequest;
 import com.deal4u.fourplease.domain.payment.dto.TossPaymentConfirmResponse;
+import com.deal4u.fourplease.domain.payment.entity.Payment;
 import com.deal4u.fourplease.global.exception.GlobalException;
 import com.deal4u.fourplease.global.lock.NamedLock;
 import com.deal4u.fourplease.global.lock.NamedLockProvider;
@@ -28,26 +33,56 @@ public class PaymentService {
     private final TossApiClient tossApiClient;
     private final NamedLockProvider namedLockProvider;
     private final PaymentTransactionService paymentTransactionService;
+    private final BidRepository bidRepository;
+    private final OrderService orderService;
 
     public void paymentConfirm(TossPaymentConfirmRequest tossPaymentConfirmRequest) {
         OrderId orderId = OrderId.create(tossPaymentConfirmRequest.orderId());
         Order order = paymentTransactionService.getOrderOrThrow(orderId);
-
         Auction auction = order.getAuction();
         validateAmount(tossPaymentConfirmRequest, order);
 
         NamedLock lock = getNamedLock(auction);
         lock.lock();
 
+        Payment payment = null;
+        boolean shouldCloseAuction = true;
+
         try {
             TossPaymentConfirmResponse response = callTossPaymentApi(tossPaymentConfirmRequest);
             validatePaymentSuccess(response);
 
-            paymentTransactionService.savePayment(order, tossPaymentConfirmRequest, response,
-                    auction);
+            payment = paymentTransactionService.savePayment(order, tossPaymentConfirmRequest,
+                    response, auction);
 
+            if (order.getOrderType().equals(OrderType.BUY_NOW)) {
+                BigDecimal currentMaxBidPrice = getCurrentMaxBidPrice(auction.getAuctionId());
+
+                shouldCloseAuction = validateInstantBidPrice(auction, currentMaxBidPrice);
+
+                if (!shouldCloseAuction) {
+                    paymentTransactionService.updatePaymentStatusToFailed(payment, order);
+                }
+            }
+
+        } catch (GlobalException e) {
+            if (payment != null) {
+                paymentTransactionService.updatePaymentStatusToFailed(payment, order);
+            }
         } finally {
+            if (shouldCloseAuction) {
+                orderService.closeAuction(auction);
+            }
             lock.unlock();
+        }
+    }
+
+    private boolean validateInstantBidPrice(Auction auction, BigDecimal currentMaxBidPrice) {
+        try {
+            validateInstancePrice(auction, currentMaxBidPrice);
+            return true;
+        } catch (GlobalException e) {
+            return false;
         }
     }
 
@@ -63,8 +98,7 @@ public class PaymentService {
         return namedLockProvider.getBottleLock(key);
     }
 
-    private TossPaymentConfirmResponse callTossPaymentApi(
-            TossPaymentConfirmRequest request) {
+    private TossPaymentConfirmResponse callTossPaymentApi(TossPaymentConfirmRequest request) {
         try {
             return tossApiClient.confirmPayment(request);
         } catch (FeignException e) {
@@ -78,5 +112,15 @@ public class PaymentService {
         if (!PAYMENT_SUCCESS.equals(response.status())) {
             throw PAYMENT_CONFIRMATION_FAILED.toException();
         }
+    }
+
+    private static void validateInstancePrice(Auction auction, BigDecimal currentMaxBidPrice) {
+        if (auction.getInstantBidPrice().compareTo(currentMaxBidPrice) < 0) {
+            throw INVALID_PRICE_NOT_UPPER.toException();
+        }
+    }
+
+    private BigDecimal getCurrentMaxBidPrice(Long auctionId) {
+        return bidRepository.findMaxBidPriceByAuctionId(auctionId).orElse(BigDecimal.ZERO);
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentTransactionService.java
@@ -43,4 +43,9 @@ class PaymentTransactionService {
         payment.statusFailed();
         order.failed();
     }
+
+    @Transactional
+    public void paymentStatusSuccess(Payment payment) {
+        payment.statusSuccess();
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentTransactionService.java
@@ -29,13 +29,18 @@ class PaymentTransactionService {
     }
 
     @Transactional
-    public void savePayment(Order order,
-                            TossPaymentConfirmRequest req,
-                            TossPaymentConfirmResponse resp,
-                            Auction auction
+    public Payment savePayment(Order order,
+                               TossPaymentConfirmRequest req,
+                               TossPaymentConfirmResponse resp,
+                               Auction auction
     ) {
         Payment payment = PaymentMapper.toPayment(order, req, resp);
-        auction.close();
-        paymentRepository.save(payment);
+        return paymentRepository.save(payment);
+    }
+
+    @Transactional
+    public void updatePaymentStatusToFailed(Payment payment, Order order) {
+        payment.statusFailed();
+        order.failed();
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentTransactionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/payment/service/PaymentTransactionService.java
@@ -3,6 +3,7 @@ package com.deal4u.fourplease.domain.payment.service;
 import static com.deal4u.fourplease.global.exception.ErrorCode.ORDER_NOT_FOUND;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.order.entity.Order;
 import com.deal4u.fourplease.domain.order.entity.OrderId;
 import com.deal4u.fourplease.domain.order.repository.OrderRepository;
@@ -45,7 +46,11 @@ class PaymentTransactionService {
     }
 
     @Transactional
-    public void paymentStatusSuccess(Payment payment) {
+    public void paymentStatusSuccess(Payment payment, Order order, Auction auction) {
+        if (auction.getStatus().equals(AuctionStatus.OPEN)) {
+            auction.close();
+        }
+        order.success();
         payment.statusSuccess();
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/settlement/entity/Settlement.java
+++ b/src/main/java/com/deal4u/fourplease/domain/settlement/entity/Settlement.java
@@ -45,4 +45,14 @@ public class Settlement extends BaseDateEntity {
     private String rejectedReason;
 
     private LocalDateTime paidAt;
+    
+    public void updateStatus(SettlementStatus status, LocalDateTime paidAt, String rejectedReason) {
+        this.status = status;
+        if (status == SettlementStatus.SUCCESS) {
+            this.paidAt = paidAt;
+        }
+        if (status == SettlementStatus.REJECTED) {
+            this.rejectedReason = rejectedReason;
+        }
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
@@ -1,7 +1,26 @@
 package com.deal4u.fourplease.domain.settlement.repository;
 
+import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.settlement.entity.Settlement;
+import com.deal4u.fourplease.domain.settlement.entity.SettlementStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface SettlementRepository extends CrudRepository<Settlement, Long> {
+
+    @Query("SELECT s FROM Settlement s " +
+            "JOIN FETCH s.auction a " +
+            "WHERE a = :auction AND a.status = 'CLOSED'")
+    Optional<Settlement> findByAuctionWithJoin(Auction auction);
+
+    @Query("SELECT s FROM Settlement s " +
+            "JOIN FETCH s.auction " +
+            "WHERE s.status = :status " +
+            "AND s.paymentDeadline < :currentTime")
+    List<Settlement> findExpiredSettlements(@Param("status") SettlementStatus status,
+                                            @Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
@@ -12,15 +12,15 @@ import org.springframework.data.repository.query.Param;
 
 public interface SettlementRepository extends CrudRepository<Settlement, Long> {
 
-    @Query("SELECT s FROM Settlement s " +
-            "JOIN FETCH s.auction a " +
-            "WHERE a = :auction AND a.status = 'CLOSED'")
+    @Query("SELECT s FROM Settlement s "
+            + "JOIN FETCH s.auction a "
+            + "WHERE a = :auction AND a.status = 'CLOSED'")
     Optional<Settlement> findByAuctionWithJoin(Auction auction);
 
-    @Query("SELECT s FROM Settlement s " +
-            "JOIN FETCH s.auction " +
-            "WHERE s.status = :status " +
-            "AND s.paymentDeadline < :currentTime")
+    @Query("SELECT s FROM Settlement s "
+            + "JOIN FETCH s.auction "
+            + "WHERE s.status = :status "
+            + "AND s.paymentDeadline < :currentTime")
     List<Settlement> findExpiredSettlements(@Param("status") SettlementStatus status,
                                             @Param("currentTime") LocalDateTime currentTime);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
@@ -1,12 +1,7 @@
 package com.deal4u.fourplease.domain.settlement.repository;
 
-import com.deal4u.fourplease.domain.auction.entity.Auction;
-import com.deal4u.fourplease.domain.bid.entity.Bidder;
 import com.deal4u.fourplease.domain.settlement.entity.Settlement;
-import com.deal4u.fourplease.domain.settlement.entity.SettlementStatus;
 import org.springframework.data.repository.CrudRepository;
 
 public interface SettlementRepository extends CrudRepository<Settlement, Long> {
-    boolean existsByAuctionAndBidderAndStatus(Auction auction, Bidder bidder,
-                                              SettlementStatus status);
 }

--- a/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
+++ b/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
@@ -8,41 +8,41 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "엔티티를 찾을 수 없습니다."),
-    AUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 경매를 찾을 수 없습니다."),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    // 400 - Bad Request,
+    EMPTY_LIST(HttpStatus.BAD_REQUEST, "빈 리스트 입니다."),
     INVALID_AUCTION_BIDDER(HttpStatus.BAD_REQUEST, "해당 사용자는 경매의 낙찰자가 아닙니다."),
     INVALID_ORDER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 타입입니다."),
     INVALID_INSTANT_BID_PRICE(HttpStatus.BAD_REQUEST, "요청된 가격이 즉시 입찰가와 일치하지 않습니다."),
     INVALID_BID_PRICE(HttpStatus.BAD_REQUEST, "요청된 가격이 낙찰가와 일치하지 않습니다."),
-
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "결제 금액이 주문 금액과 일치하지 않습니다."),
     INVALID_USER(HttpStatus.BAD_REQUEST, "결제자 정보가 올바르지 않습니다."),
     PAYMENT_CONFIRMATION_FAILED(HttpStatus.BAD_REQUEST, "결제 승인이 실패했습니다."),
     PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "결제 처리 중 오류가 발생했습니다."),
+    WEBSOCKET_INVALID_REQUEST_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 요청 형식입니다."),
+    INVALID_PRICE_NOT_UPPER(HttpStatus.BAD_REQUEST, "요청된 가격이 즉시 입찰가보다 낮습니다."),
 
-    PAYMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리된 결제입니다"),
-
-    BID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 입찰 내역을 찾을 수 없습니다."),
-
+    // 403 - Forbidden
     BID_FORBIDDEN_PRICE(HttpStatus.FORBIDDEN, "기존 입찰 금액보다 높은 금액을 입력해주세요."),
-
     AUCTION_NOT_OPEN(HttpStatus.FORBIDDEN, "해당 경매는 종료되었습니다."),
 
+    // 404 - Not Found
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "엔티티를 찾을 수 없습니다."),
+    AUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 경매를 찾을 수 없습니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정산을 찾을 수 없습니다."),
+    BID_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 입찰 내역을 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
-
-    WEBSOCKET_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "WebSocket 메시지 전송 중 오류가 발생하였습니다."),
-
-    WEBSOCKET_INVALID_REQUEST_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 요청 형식입니다."),
-
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
-
-    EMPTY_LIST(HttpStatus.BAD_REQUEST, "빈 리스트 입니다."),
-
     BIDPERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "경매 기간을 찾을 수 없습니다."),
+    BID_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "경매 기간을 찾을 수 없습니다."),
+    SECOND_HIGHEST_BIDDER_NOT_FOUND(HttpStatus.NOT_FOUND, "차상위 입찰자를 찾을 수 없습니다."),
 
-    BID_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "경매 기간을 찾을 수 없습니다.");
+    // 409 - Conflict
+    PAYMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리된 결제입니다"),
+
+    // 500 - Internal Server Error
+    WEBSOCKET_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "WebSocket 메시지 전송 중 오류가 발생하였습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
+++ b/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     PAYMENT_CONFIRMATION_FAILED(HttpStatus.BAD_REQUEST, "결제 승인이 실패했습니다."),
     PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "결제 처리 중 오류가 발생했습니다."),
     WEBSOCKET_INVALID_REQUEST_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 요청 형식입니다."),
-    INVALID_PRICE_NOT_UPPER(HttpStatus.BAD_REQUEST, "요청된 가격이 즉시 입찰가보다 낮습니다."),
+    INVALID_PRICE_NOT_UPPER(HttpStatus.BAD_REQUEST, "즉시 구매 가격이 현재 최고 입찰가보다 낮습니다."),
 
     // 403 - Forbidden
     BID_FORBIDDEN_PRICE(HttpStatus.FORBIDDEN, "기존 입찰 금액보다 높은 금액을 입력해주세요."),

--- a/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
@@ -170,7 +170,7 @@ class OrderServiceTest {
             assertThat(savedOrder.getPrice()).isEqualByComparingTo(
                     openAuction.getInstantBidPrice());
             assertThat(savedOrder.getOrderType()).isEqualTo(OrderType.BUY_NOW);
-            assertThat(savedOrder.getOrderStatus()).isEqualTo(OrderStatus.SUCCESS);
+            assertThat(savedOrder.getOrderStatus()).isEqualTo(OrderStatus.PENDING);
         }
 
         @Test
@@ -225,7 +225,7 @@ class OrderServiceTest {
             assertThat(capturedOrder.getPrice()).isEqualByComparingTo(winningBid.getPrice());
             assertThat(capturedOrder.getAuction().getAuctionId()).isEqualTo(auctionId);
             assertThat(capturedOrder.getOrderType()).isEqualTo(OrderType.AWARD);
-            assertThat(capturedOrder.getOrderStatus()).isEqualTo(OrderStatus.SUCCESS);
+            assertThat(capturedOrder.getOrderStatus()).isEqualTo(OrderStatus.PENDING);
         }
 
         @Test

--- a/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
@@ -3,7 +3,6 @@ package com.deal4u.fourplease.domain.order.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -475,25 +474,6 @@ class OrderServiceTest {
                     .isEqualTo(HttpStatus.NOT_FOUND);
 
             verify(orderRepository, times(1)).findByIdWithAuctionAndProduct(orderId);
-        }
-    }
-
-    @Nested
-    class CloseAuctionTests {
-
-        @Test
-        @DisplayName("경매 종료가 정상적으로 수행되는 경우")
-        void testCloseAuction_Successful() {
-            // Given
-            Auction auctionToClose = Auction.builder()
-                    .auctionId(1L)
-                    .status(AuctionStatus.OPEN)
-                    .build();
-
-            // When
-            orderService.closeAuction(auctionToClose);
-
-            verify(auctionRepository, times(0)).save(any());
         }
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
@@ -376,7 +376,6 @@ class OrderServiceTest {
             assertThat(OrderType.fromString("BUY_NOW")).isEqualTo(OrderType.BUY_NOW);
             assertThat(OrderType.fromString("AWARD")).isEqualTo(OrderType.AWARD);
 
-            // 대소문자 구분 없이 작동하는지 확인
             assertThat(OrderType.fromString("buy_now")).isEqualTo(OrderType.BUY_NOW);
             assertThat(OrderType.fromString("award")).isEqualTo(OrderType.AWARD);
         }

--- a/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import com.deal4u.fourplease.domain.auction.entity.Address;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.entity.Seller;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
@@ -25,6 +26,7 @@ import com.deal4u.fourplease.domain.order.dto.OrderResponse;
 import com.deal4u.fourplease.domain.order.dto.OrderUpdateRequest;
 import com.deal4u.fourplease.domain.order.entity.Order;
 import com.deal4u.fourplease.domain.order.entity.OrderId;
+import com.deal4u.fourplease.domain.order.entity.OrderStatus;
 import com.deal4u.fourplease.domain.order.entity.OrderType;
 import com.deal4u.fourplease.domain.order.entity.Orderer;
 import com.deal4u.fourplease.domain.order.repository.OrderRepository;
@@ -58,7 +60,8 @@ class OrderServiceTest {
     @InjectMocks
     private OrderService orderService;
 
-    private Auction auction;
+    private Auction openAuction;
+    private Auction closedAuction;
     private Member member;
     private OrderCreateRequest orderCreateRequest;
     private OrderCreateRequest awardOrderCreateRequest;
@@ -70,10 +73,19 @@ class OrderServiceTest {
 
     @BeforeEach
     void setUp() {
-        auction = Auction.builder()
+        openAuction = Auction.builder()
                 .auctionId(1L)
                 .startingPrice(new BigDecimal("100"))
                 .instantBidPrice(new BigDecimal("20000"))
+                .status(AuctionStatus.OPEN)
+                .deleted(false)
+                .build();
+
+        closedAuction = Auction.builder()
+                .auctionId(2L)
+                .startingPrice(new BigDecimal("100"))
+                .instantBidPrice(new BigDecimal("20000"))
+                .status(AuctionStatus.CLOSED)
                 .deleted(false)
                 .build();
 
@@ -121,7 +133,7 @@ class OrderServiceTest {
         Bidder bidder = Bidder.createBidder(member);
         winningBid = Bid.builder()
                 .bidId(1L)
-                .auction(auction)
+                .auction(closedAuction)
                 .bidder(bidder)
                 .price(new BigDecimal("15000"))
                 .bidTime(LocalDateTime.now())
@@ -141,7 +153,7 @@ class OrderServiceTest {
             String orderType = "BUY_NOW";
 
             when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(auctionId))
-                    .thenReturn(Optional.of(auction));
+                    .thenReturn(Optional.of(openAuction));
             when(memberRepository.findById(1L))
                     .thenReturn(Optional.of(member));
 
@@ -150,7 +162,15 @@ class OrderServiceTest {
 
             // Then
             assertNotNull(orderId);
-            verify(orderRepository, times(1)).save(any(Order.class));
+
+            ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+            verify(orderRepository, times(1)).save(orderCaptor.capture());
+
+            Order savedOrder = orderCaptor.getValue();
+            assertThat(savedOrder.getPrice()).isEqualByComparingTo(
+                    openAuction.getInstantBidPrice());
+            assertThat(savedOrder.getOrderType()).isEqualTo(OrderType.BUY_NOW);
+            assertThat(savedOrder.getOrderStatus()).isEqualTo(OrderStatus.SUCCESS);
         }
 
         @Test
@@ -161,11 +181,11 @@ class OrderServiceTest {
             String orderType = "BUY_NOW";
 
             OrderCreateRequest invalidPriceRequest = OrderCreateRequest.builder()
-                    .price(10000L)
+                    .price(10000L) // 즉시 구매가(20000L)와 다른 가격
                     .build();
 
             when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(auctionId))
-                    .thenReturn(Optional.of(auction));
+                    .thenReturn(Optional.of(openAuction));
             when(memberRepository.findById(1L))
                     .thenReturn(Optional.of(member));
 
@@ -182,19 +202,18 @@ class OrderServiceTest {
         @DisplayName("낙찰자가 AWARD 타입의 주문을 정상적으로 생성하는 경우")
         void testCreateOrder_AwardSuccessful() {
             // Given
+            Long auctionId = 2L;
             String orderType = "AWARD";
 
-            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(
-                    auction.getAuctionId()))
-                    .thenReturn(Optional.of(auction));
+            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusClosed(auctionId))
+                    .thenReturn(Optional.of(closedAuction));
             when(memberRepository.findById(1L))
                     .thenReturn(Optional.of(member));
-            when(bidRepository.findSuccessFulBid(auction.getAuctionId(), member))
+            when(bidRepository.findSuccessFulBid(auctionId, member))
                     .thenReturn(Optional.of(winningBid));
 
             // When
-            String orderId = orderService.saveOrder(auction.getAuctionId(), orderType,
-                    awardOrderCreateRequest);
+            String orderId = orderService.saveOrder(auctionId, orderType, awardOrderCreateRequest);
 
             // Then
             assertNotNull(orderId);
@@ -203,32 +222,33 @@ class OrderServiceTest {
             verify(orderRepository, times(1)).save(orderCaptor.capture());
 
             Order capturedOrder = orderCaptor.getValue();
-            assertThat(capturedOrder.getPrice()).isNotNull();
             assertThat(capturedOrder.getPrice()).isEqualByComparingTo(winningBid.getPrice());
-            assertThat(capturedOrder.getAuction().getAuctionId()).isEqualTo(auction.getAuctionId());
+            assertThat(capturedOrder.getAuction().getAuctionId()).isEqualTo(auctionId);
+            assertThat(capturedOrder.getOrderType()).isEqualTo(OrderType.AWARD);
+            assertThat(capturedOrder.getOrderStatus()).isEqualTo(OrderStatus.SUCCESS);
         }
 
         @Test
         @DisplayName("AWARD 타입의 주문에서 가격이 일치하지 않는 경우 예외 발생")
         void testCreateOrder_AwardInvalidPrice() {
             // Given
+            Long auctionId = 2L;
             String orderType = "AWARD";
 
             OrderCreateRequest invalidPriceRequest = OrderCreateRequest.builder()
                     .price(10000L)  // 낙찰가(15000L)와 다른 가격
                     .build();
 
-            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(
-                    auction.getAuctionId()))
-                    .thenReturn(Optional.of(auction));
+            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusClosed(auctionId))
+                    .thenReturn(Optional.of(closedAuction));
             when(memberRepository.findById(1L))
                     .thenReturn(Optional.of(member));
-            when(bidRepository.findSuccessFulBid(auction.getAuctionId(), member))
+            when(bidRepository.findSuccessFulBid(auctionId, member))
                     .thenReturn(Optional.of(winningBid));
 
             // When, Then
-            assertThatThrownBy(() -> orderService.saveOrder(auction.getAuctionId(), orderType,
-                    invalidPriceRequest))
+            assertThatThrownBy(
+                    () -> orderService.saveOrder(auctionId, orderType, invalidPriceRequest))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage("요청된 가격이 낙찰가와 일치하지 않습니다.")
                     .extracting("status")
@@ -236,8 +256,8 @@ class OrderServiceTest {
         }
 
         @Test
-        @DisplayName("경매를 찾을 수 없는 경우 예외 발생")
-        void testCreateOrder_AuctionNotFound() {
+        @DisplayName("BUY_NOW 타입에서 OPEN 상태가 아닌 경매에 대한 주문 시 예외 발생")
+        void testCreateOrder_BuyNowAuctionNotOpen() {
             // Given
             Long auctionId = 1L;
             String orderType = "BUY_NOW";
@@ -250,6 +270,27 @@ class OrderServiceTest {
             // When, Then
             assertThatThrownBy(
                     () -> orderService.saveOrder(auctionId, orderType, orderCreateRequest))
+                    .isInstanceOf(GlobalException.class)
+                    .hasMessage("해당 경매를 찾을 수 없습니다.")
+                    .extracting("status")
+                    .isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("AWARD 타입에서 CLOSED 상태가 아닌 경매에 대한 주문 시 예외 발생")
+        void testCreateOrder_AwardAuctionNotClosed() {
+            // Given
+            Long auctionId = 2L;
+            String orderType = "AWARD";
+
+            when(memberRepository.findById(1L))
+                    .thenReturn(Optional.of(member));
+            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusClosed(auctionId))
+                    .thenReturn(Optional.empty());
+
+            // When, Then
+            assertThatThrownBy(
+                    () -> orderService.saveOrder(auctionId, orderType, awardOrderCreateRequest))
                     .isInstanceOf(GlobalException.class)
                     .hasMessage("해당 경매를 찾을 수 없습니다.")
                     .extracting("status")
@@ -279,11 +320,11 @@ class OrderServiceTest {
         @DisplayName("AWARD 타입의 주문에서 유효하지 않은 입찰자일 경우 예외 발생")
         void testCreateOrder_InvalidBidderForAward() {
             // Given
-            Long auctionId = 1L;
+            Long auctionId = 2L;
             String orderType = "AWARD";
 
-            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(auctionId))
-                    .thenReturn(Optional.of(auction));
+            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusClosed(auctionId))
+                    .thenReturn(Optional.of(closedAuction));
             when(memberRepository.findById(1L))
                     .thenReturn(Optional.of(member));
             when(bidRepository.findSuccessFulBid(auctionId, member))
@@ -312,88 +353,6 @@ class OrderServiceTest {
                     .hasMessage("유효하지 않은 주문 타입입니다.")
                     .extracting("status")
                     .isEqualTo(HttpStatus.BAD_REQUEST);
-        }
-
-        @Test
-        @DisplayName("BUY_NOW 타입 주문에서 즉시 구매가 정확히 처리되는지 확인")
-        void testCreateOrder_BuyNowTypeValidation() {
-            // Given
-            Long auctionId = 1L;
-            String orderType = "BUY_NOW";
-
-            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(auctionId))
-                    .thenReturn(Optional.of(auction));
-            when(memberRepository.findById(1L))
-                    .thenReturn(Optional.of(member));
-
-            // When
-            String orderId = orderService.saveOrder(auctionId, orderType, orderCreateRequest);
-
-            // Then
-            assertNotNull(orderId);
-
-            ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
-            verify(orderRepository, times(1)).save(orderCaptor.capture());
-
-            Order capturedOrder = orderCaptor.getValue();
-            assertThat(capturedOrder.getPrice()).isEqualByComparingTo(
-                    auction.getInstantBidPrice());
-            assertThat(capturedOrder.getAuction().getAuctionId()).isEqualTo(auction.getAuctionId());
-        }
-
-        @Test
-        @DisplayName("AWARD 타입 주문에서 낙찰가가 정확히 처리되는지 확인")
-        void testCreateOrder_AwardTypeValidation() {
-            // Given
-            Long auctionId = 1L;
-            String orderType = "AWARD";
-
-            when(auctionRepository.findByAuctionIdAndDeletedFalseAndStatusOpen(auctionId))
-                    .thenReturn(Optional.of(auction));
-            when(memberRepository.findById(1L))
-                    .thenReturn(Optional.of(member));
-            when(bidRepository.findSuccessFulBid(auctionId, member))
-                    .thenReturn(Optional.of(winningBid));
-
-            // When
-            String orderId = orderService.saveOrder(auctionId, orderType, awardOrderCreateRequest);
-
-            // Then
-            assertNotNull(orderId);
-
-            ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
-            verify(orderRepository, times(1)).save(orderCaptor.capture());
-
-            Order capturedOrder = orderCaptor.getValue();
-            assertThat(capturedOrder.getPrice()).isEqualByComparingTo(winningBid.getPrice());
-            assertThat(capturedOrder.getAuction().getAuctionId()).isEqualTo(auction.getAuctionId());
-        }
-
-        @Test
-        @DisplayName("OrderType enum의 fromString 메서드 - 유효한 타입들 검증")
-        void testOrderType_FromStringValidation() {
-            // Given & When & Then
-            assertThat(OrderType.fromString("BUY_NOW")).isEqualTo(OrderType.BUY_NOW);
-            assertThat(OrderType.fromString("AWARD")).isEqualTo(OrderType.AWARD);
-
-            assertThat(OrderType.fromString("buy_now")).isEqualTo(OrderType.BUY_NOW);
-            assertThat(OrderType.fromString("award")).isEqualTo(OrderType.AWARD);
-        }
-
-        @Test
-        @DisplayName("OrderType enum의 fromString 메서드 - 유효하지 않은 문자열 예외 검증")
-        void testOrderType_FromStringInvalidValue() {
-            // Given & When & Then
-            assertThatThrownBy(() -> OrderType.fromString("INVALID"))
-                    .isInstanceOf(IllegalArgumentException.class);
-        }
-
-        @Test
-        @DisplayName("OrderType enum의 fromString 메서드 - null 값 예외 검증")
-        void testOrderType_FromStringNullValue() {
-            // Given & When & Then
-            assertThatThrownBy(() -> OrderType.fromString(null))
-                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -474,7 +433,7 @@ class OrderServiceTest {
                     .id(orderId)
                     .orderId(OrderId.generate())
                     .price(new BigDecimal("100.0"))
-                    .auction(auction)
+                    .auction(openAuction)
                     .address(originalAddress)
                     .phone(null)
                     .content(null)
@@ -516,6 +475,25 @@ class OrderServiceTest {
                     .isEqualTo(HttpStatus.NOT_FOUND);
 
             verify(orderRepository, times(1)).findByIdWithAuctionAndProduct(orderId);
+        }
+    }
+
+    @Nested
+    class CloseAuctionTests {
+
+        @Test
+        @DisplayName("경매 종료가 정상적으로 수행되는 경우")
+        void testCloseAuction_Successful() {
+            // Given
+            Auction auctionToClose = Auction.builder()
+                    .auctionId(1L)
+                    .status(AuctionStatus.OPEN)
+                    .build();
+
+            // When
+            orderService.closeAuction(auctionToClose);
+
+            verify(auctionRepository, times(0)).save(any());
         }
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/payment/service/PaymentServiceTest.java
@@ -1,14 +1,10 @@
 package com.deal4u.fourplease.domain.payment.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
@@ -21,21 +17,19 @@ import com.deal4u.fourplease.domain.payment.config.TossApiClient;
 import com.deal4u.fourplease.domain.payment.dto.TossPaymentConfirmRequest;
 import com.deal4u.fourplease.domain.payment.dto.TossPaymentConfirmResponse;
 import com.deal4u.fourplease.domain.payment.entity.Payment;
-import com.deal4u.fourplease.global.exception.ErrorCode;
 import com.deal4u.fourplease.global.exception.GlobalException;
 import com.deal4u.fourplease.global.lock.NamedLock;
 import com.deal4u.fourplease.global.lock.NamedLockProvider;
-import feign.FeignException;
 import java.math.BigDecimal;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentServiceTest {
@@ -58,14 +52,16 @@ class PaymentServiceTest {
     @Mock
     private OrderService orderService;
 
+    @Mock
+    private Payment payment;
+
     @InjectMocks
     private PaymentService paymentService;
 
     private TossPaymentConfirmRequest confirmRequest;
-    private Order order;
     private Order buyNowOrder;
+    private Order awardOrder;
     private Auction auction;
-    private Payment payment;
     private TossPaymentConfirmResponse successResponse;
     private TossPaymentConfirmResponse failedResponse;
 
@@ -84,15 +80,8 @@ class PaymentServiceTest {
         confirmRequest = new TossPaymentConfirmRequest(
                 "paymentKey123",
                 "order123",
-                10000
+                100000
         );
-
-        order = Order.builder()
-                .orderId(OrderId.create("order123"))
-                .auction(auction)
-                .price(new BigDecimal("10000"))
-                .orderType(OrderType.AWARD)
-                .build();
 
         buyNowOrder = Order.builder()
                 .orderId(OrderId.create("order123"))
@@ -101,279 +90,135 @@ class PaymentServiceTest {
                 .orderType(OrderType.BUY_NOW)
                 .build();
 
-        payment = Payment.builder()
-                .paymentId(1L)
-                .paymentKey("paymentKey123")
-                .amount(new BigDecimal("10000"))
+        awardOrder = Order.builder()
+                .orderId(OrderId.create("order123"))
+                .auction(auction)
+                .price(new BigDecimal("80000"))
+                .orderType(OrderType.AWARD)
                 .build();
 
         successResponse = new TossPaymentConfirmResponse(
-                "DONE",
-                "paymentKey123",
                 "order123",
+                "paymentKey123",
+                "DONE",
                 "2025-07-12",
                 "2025-07-12",
-                10000
+                100000
         );
 
         failedResponse = new TossPaymentConfirmResponse(
+                "order123",
+                "paymentKey123",
                 "FAILED",
-                "paymentKey123",
-                "order123",
-                "2025-07-12",
-                "2025-07-12",
-                10000
-        );
-    }
-
-    @Test
-    @DisplayName("일반 경매 결제 승인 성공")
-    void paymentConfirm_Success_NormalBid() {
-        // given
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(order);
-        when(namedLockProvider.getBottleLock(anyString()))
-                .thenReturn(namedLock);
-        when(tossApiClient.confirmPayment(confirmRequest))
-                .thenReturn(successResponse);
-        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
-                .thenReturn(payment);
-
-        doNothing().when(namedLock).lock();
-        doNothing().when(namedLock).unlock();
-
-        // when
-        assertDoesNotThrow(() -> paymentService.paymentConfirm(confirmRequest));
-
-        // then
-        verify(paymentTransactionService).getOrderOrThrow(any(OrderId.class));
-        verify(namedLock).lock();
-        verify(tossApiClient).confirmPayment(confirmRequest);
-        verify(paymentTransactionService).savePayment(order, confirmRequest, successResponse,
-                auction);
-        verify(orderService).closeAuction(auction);
-        verify(namedLock).unlock();
-    }
-
-    @Test
-    @DisplayName("즉시 구매 결제 승인 성공")
-    void paymentConfirm_Success_BuyNow() {
-        // given
-        TossPaymentConfirmRequest buyNowRequest = new TossPaymentConfirmRequest(
-                "paymentKey123",
-                "order123",
-                100000
-        );
-
-        TossPaymentConfirmResponse buyNowResponse = new TossPaymentConfirmResponse(
-                "DONE",
-                "paymentKey123",
-                "order123",
                 "2025-07-12",
                 "2025-07-12",
                 100000
         );
+    }
 
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(buyNowOrder);
-        when(namedLockProvider.getBottleLock(anyString()))
-                .thenReturn(namedLock);
-        when(tossApiClient.confirmPayment(buyNowRequest))
-                .thenReturn(buyNowResponse);
-        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
-                .thenReturn(payment);
-        when(bidRepository.findMaxBidPriceByAuctionId(1L))
-                .thenReturn(Optional.of(new BigDecimal("80000")));
+    @Nested
+    class PaymentConfirmTest {
 
-        doNothing().when(namedLock).lock();
-        doNothing().when(namedLock).unlock();
+        @Test
+        @DisplayName("결제가 성공적으로 되고 상태가 변경되었다.")
+        void paymentConfirmSuccess() {
+            // given
+            given(paymentTransactionService.getOrderOrThrow(any())).willReturn(buyNowOrder);
+            given(namedLockProvider.getBottleLock(anyString())).willReturn(namedLock);
+            given(bidRepository.findMaxBidPriceByAuctionId(1L)).willReturn(
+                    Optional.of(new BigDecimal("90000")));
+            given(tossApiClient.confirmPayment(confirmRequest)).willReturn(successResponse);
+            given(paymentTransactionService.savePayment(any(), any(), any(), any())).willReturn(
+                    payment);
 
-        // when
-        assertDoesNotThrow(() -> paymentService.paymentConfirm(buyNowRequest));
+            // when
+            paymentService.paymentConfirm(confirmRequest);
 
-        // then
-        verify(bidRepository).findMaxBidPriceByAuctionId(1L);
-        verify(orderService).closeAuction(auction);
-        verify(paymentTransactionService, never()).updatePaymentStatusToFailed(any(), any());
+            // then
+            verify(paymentTransactionService).paymentStatusSuccess(payment);
+            verify(orderService).succesOrder(buyNowOrder);
+            verify(orderService).closeAuction(auction);
+            verify(namedLock).unlock();
+        }
+
+        @Test
+        @DisplayName("결제승인실패시_결제상태가_실패로_변경된다")
+        void priceMismatch() {
+            // given
+            given(paymentTransactionService.getOrderOrThrow(any())).willReturn(buyNowOrder);
+            given(namedLockProvider.getBottleLock(anyString())).willReturn(namedLock);
+            given(bidRepository.findMaxBidPriceByAuctionId(1L)).willReturn(
+                    Optional.of(new BigDecimal("90000")));
+            given(tossApiClient.confirmPayment(confirmRequest)).willReturn(failedResponse);
+            given(paymentTransactionService.savePayment(any(), any(), any(), any())).willReturn(
+                    payment);
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
+                    .isInstanceOf(GlobalException.class);
+
+            verify(paymentTransactionService).updatePaymentStatusToFailed(payment, buyNowOrder);
+            verify(orderService).succesOrder(buyNowOrder);
+            verify(orderService).closeAuction(auction);
+        }
+
+        @Test
+        @DisplayName("결제 금액불일치시 주문이 실패로 변경된다")
+        void priceUnmatch() {
+            // given
+            TossPaymentConfirmRequest invalidAmountRequest = new TossPaymentConfirmRequest(
+                    "paymentKey123",
+                    "order123",
+                    50000 // 주문 금액과 다른 금액
+            );
+            given(paymentTransactionService.getOrderOrThrow(any())).willReturn(buyNowOrder);
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.paymentConfirm(invalidAmountRequest))
+                    .isInstanceOf(GlobalException.class);
+
+            verify(orderService).faliedOrder(buyNowOrder);
+        }
+
+        @Test
+        @DisplayName("즉시구매가격이 현재최고입찰가보다 낮으면 주문이 실패로_변경된다")
+        void buyNowPriceTooLow() {
+            // given
+            given(paymentTransactionService.getOrderOrThrow(any())).willReturn(buyNowOrder);
+            given(namedLockProvider.getBottleLock(anyString())).willReturn(namedLock);
+            given(bidRepository.findMaxBidPriceByAuctionId(1L)).willReturn(
+                    Optional.of(new BigDecimal("150000"))); // 즉시구매가보다 높은 입찰가
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
+                    .isInstanceOf(GlobalException.class);
+
+            verify(orderService).faliedOrder(buyNowOrder);
+        }
     }
 
     @Test
-    @DisplayName("즉시 구매 결제 실패 - 현재 최고 입찰가가 즉시 구매 가격보다 높음")
-    void paymentConfirm_BuyNow_Failed_InvalidPrice() {
+    @DisplayName("결제 실패 시 상태가 FAILED로 변경된다")
+    void paymentFailureStatus() {
         // given
-        TossPaymentConfirmRequest buyNowRequest = new TossPaymentConfirmRequest(
-                "paymentKey123",
+        TossPaymentConfirmResponse failedResponse = new TossPaymentConfirmResponse(
                 "order123",
-                100000
-        );
-
-        TossPaymentConfirmResponse buyNowResponse = new TossPaymentConfirmResponse(
-                "DONE",
                 "paymentKey123",
-                "order123",
+                "FAILED",
                 "2025-07-12",
                 "2025-07-12",
                 100000
         );
-
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(buyNowOrder);
-        when(namedLockProvider.getBottleLock(anyString()))
-                .thenReturn(namedLock);
-        when(tossApiClient.confirmPayment(buyNowRequest))
-                .thenReturn(buyNowResponse);
-        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
-                .thenReturn(payment);
-        when(bidRepository.findMaxBidPriceByAuctionId(1L))
-                .thenReturn(Optional.of(new BigDecimal("100000"))); // 같은 가격
-
-        doNothing().when(namedLock).lock();
-        doNothing().when(namedLock).unlock();
-
-        // when & then
-        assertThatThrownBy(() -> paymentService.paymentConfirm(buyNowRequest))
-                .isInstanceOf(GlobalException.class)
-                .hasMessage("즉시 구매 가격이 현재 최고 입찰가보다 높아야 합니다.")
-                .extracting("status")
-                .isEqualTo(HttpStatus.BAD_REQUEST);
-
-        verify(paymentTransactionService).updatePaymentStatusToFailed(payment, buyNowOrder);
-        verify(orderService, never()).closeAuction(auction);
-    }
-
-    @Test
-    @DisplayName("결제 승인 실패 - 주문을 찾을 수 없음")
-    void paymentConfirm_OrderNotFound() {
-        // given
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenThrow(ErrorCode.ORDER_NOT_FOUND.toException());
-
-        // when & then
-        assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
-                .isInstanceOf(GlobalException.class)
-                .hasMessage("해당 주문을 찾을 수 없습니다.")
-                .extracting("status")
-                .isEqualTo(HttpStatus.NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("결제 승인 실패 - 토스 API 응답 상태가 실패")
-    void paymentConfirm_PaymentStatusFailed() {
-        // given
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(order);
-        when(namedLockProvider.getBottleLock(anyString()))
-                .thenReturn(namedLock);
-        when(tossApiClient.confirmPayment(confirmRequest))
-                .thenReturn(failedResponse);
-
-        doNothing().when(namedLock).lock();
-        doNothing().when(namedLock).unlock();
-
-        // when & then
-        assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
-                .isInstanceOf(GlobalException.class)
-                .hasMessage("결제 승인이 실패했습니다.")
-                .extracting("status")
-                .isEqualTo(HttpStatus.BAD_REQUEST);
-
-        verify(namedLock).unlock();
-    }
-
-    @Test
-    @DisplayName("결제 승인 실패 - 결제 금액이 주문 금액과 다름")
-    void paymentConfirm_InvalidAmount() {
-        // given
-        TossPaymentConfirmRequest invalidAmountRequest = new TossPaymentConfirmRequest(
-                "paymentKey123",
-                "order123",
-                20000  // 금액이 잘못된 경우
-        );
-
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(order);
-
-        // when & then
-        assertThatThrownBy(() -> paymentService.paymentConfirm(invalidAmountRequest))
-                .isInstanceOf(GlobalException.class)
-                .hasMessage("결제 금액이 주문 금액과 일치하지 않습니다.")
-                .extracting("status")
-                .isEqualTo(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    @DisplayName("결제 승인 실패 - 토스 API 호출 오류")
-    void paymentConfirm_TossApiError() {
-        // given
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(order);
-        when(namedLockProvider.getBottleLock(anyString()))
-                .thenReturn(namedLock);
-        when(tossApiClient.confirmPayment(confirmRequest))
-                .thenThrow(FeignException.class);
-
-        doNothing().when(namedLock).lock();
-        doNothing().when(namedLock).unlock();
-
-        // when & then
-        assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
-                .isInstanceOf(GlobalException.class)
-                .hasMessage("결제 처리 중 오류가 발생했습니다.")
-                .extracting("status")
-                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-
-        verify(namedLock).unlock();
-    }
-
-    @Test
-    @DisplayName("결제 처리 중 예외 발생 시 결제 실패로 업데이트 및 락 해제")
-    void paymentConfirm_ExceptionHandling() {
-        // given
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(order);
-        when(namedLockProvider.getBottleLock(anyString()))
-                .thenReturn(namedLock);
-        when(tossApiClient.confirmPayment(confirmRequest))
-                .thenReturn(successResponse);
-        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
-                .thenReturn(payment)
-                .thenThrow(ErrorCode.PAYMENT_CONFIRMATION_FAILED.toException());
-
-        doNothing().when(namedLock).lock();
-        doNothing().when(namedLock).unlock();
+        given(paymentTransactionService.getOrderOrThrow(any())).willReturn(buyNowOrder);
+        given(namedLockProvider.getBottleLock(anyString())).willReturn(namedLock);
+        given(tossApiClient.confirmPayment(confirmRequest)).willReturn(failedResponse);
+        given(paymentTransactionService.savePayment(any(), any(), any(), any())).willReturn(
+                payment);
 
         // when & then
         assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
                 .isInstanceOf(GlobalException.class);
 
-        verify(paymentTransactionService).updatePaymentStatusToFailed(payment, order);
-        verify(namedLock).unlock();
-    }
-
-    @Test
-    @DisplayName("락 사용 검증 - 정확한 키로 락 획득")
-    void paymentConfirm_LockKeyVerification() {
-        // given
-        String expectedLockKey = "auction-lock:" + auction.getAuctionId();
-
-        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
-                .thenReturn(order);
-        when(namedLockProvider.getBottleLock(expectedLockKey))
-                .thenReturn(namedLock);
-        when(tossApiClient.confirmPayment(confirmRequest))
-                .thenReturn(successResponse);
-        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
-                .thenReturn(payment);
-
-        doNothing().when(namedLock).lock();
-        doNothing().when(namedLock).unlock();
-
-        // when
-        assertDoesNotThrow(() -> paymentService.paymentConfirm(confirmRequest));
-
-        // then
-        verify(namedLockProvider).getBottleLock(expectedLockKey);
-        verify(namedLock, times(1)).lock();
-        verify(namedLock, times(1)).unlock();
+        verify(paymentTransactionService).updatePaymentStatusToFailed(payment, buyNowOrder);
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/payment/service/PaymentServiceTest.java
@@ -1,24 +1,33 @@
 package com.deal4u.fourplease.domain.payment.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
+import com.deal4u.fourplease.domain.bid.repository.BidRepository;
 import com.deal4u.fourplease.domain.order.entity.Order;
 import com.deal4u.fourplease.domain.order.entity.OrderId;
+import com.deal4u.fourplease.domain.order.entity.OrderType;
+import com.deal4u.fourplease.domain.order.service.OrderService;
 import com.deal4u.fourplease.domain.payment.config.TossApiClient;
 import com.deal4u.fourplease.domain.payment.dto.TossPaymentConfirmRequest;
 import com.deal4u.fourplease.domain.payment.dto.TossPaymentConfirmResponse;
+import com.deal4u.fourplease.domain.payment.entity.Payment;
 import com.deal4u.fourplease.global.exception.ErrorCode;
 import com.deal4u.fourplease.global.exception.GlobalException;
 import com.deal4u.fourplease.global.lock.NamedLock;
 import com.deal4u.fourplease.global.lock.NamedLockProvider;
+import feign.FeignException;
 import java.math.BigDecimal;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,18 +52,26 @@ class PaymentServiceTest {
     @Mock
     private NamedLock namedLock;
 
+    @Mock
+    private BidRepository bidRepository;
+
+    @Mock
+    private OrderService orderService;
+
     @InjectMocks
     private PaymentService paymentService;
 
     private TossPaymentConfirmRequest confirmRequest;
     private Order order;
+    private Order buyNowOrder;
+    private Auction auction;
+    private Payment payment;
     private TossPaymentConfirmResponse successResponse;
     private TossPaymentConfirmResponse failedResponse;
 
     @BeforeEach
     void setUp() {
-
-        Auction auction = Auction.builder()
+        auction = Auction.builder()
                 .auctionId(1L)
                 .product(null)
                 .startingPrice(new BigDecimal("50000"))
@@ -74,12 +91,26 @@ class PaymentServiceTest {
                 .orderId(OrderId.create("order123"))
                 .auction(auction)
                 .price(new BigDecimal("10000"))
+                .orderType(OrderType.AWARD)
+                .build();
+
+        buyNowOrder = Order.builder()
+                .orderId(OrderId.create("order123"))
+                .auction(auction)
+                .price(new BigDecimal("100000"))
+                .orderType(OrderType.BUY_NOW)
+                .build();
+
+        payment = Payment.builder()
+                .paymentId(1L)
+                .paymentKey("paymentKey123")
+                .amount(new BigDecimal("10000"))
                 .build();
 
         successResponse = new TossPaymentConfirmResponse(
-                "order123",
-                "paymentKey123",
                 "DONE",
+                "paymentKey123",
+                "order123",
                 "2025-07-12",
                 "2025-07-12",
                 10000
@@ -96,11 +127,8 @@ class PaymentServiceTest {
     }
 
     @Test
-    @DisplayName("결제 승인 성공 - 정상적인 결제 처리")
-    void paymentConfirm_Success_Improved() {
-
-        String LOCK_PREFIX = "auction-lock:";
-
+    @DisplayName("일반 경매 결제 승인 성공")
+    void paymentConfirm_Success_NormalBid() {
         // given
         when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
                 .thenReturn(order);
@@ -108,21 +136,109 @@ class PaymentServiceTest {
                 .thenReturn(namedLock);
         when(tossApiClient.confirmPayment(confirmRequest))
                 .thenReturn(successResponse);
+        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
+                .thenReturn(payment);
 
         doNothing().when(namedLock).lock();
         doNothing().when(namedLock).unlock();
 
         // when
-        paymentService.paymentConfirm(confirmRequest);
+        assertDoesNotThrow(() -> paymentService.paymentConfirm(confirmRequest));
 
         // then
         verify(paymentTransactionService).getOrderOrThrow(any(OrderId.class));
         verify(namedLock).lock();
         verify(tossApiClient).confirmPayment(confirmRequest);
         verify(paymentTransactionService).savePayment(order, confirmRequest, successResponse,
-                order.getAuction());
+                auction);
+        verify(orderService).closeAuction(auction);
         verify(namedLock).unlock();
-        verify(namedLockProvider).getBottleLock(LOCK_PREFIX + order.getAuction().getAuctionId());
+    }
+
+    @Test
+    @DisplayName("즉시 구매 결제 승인 성공")
+    void paymentConfirm_Success_BuyNow() {
+        // given
+        TossPaymentConfirmRequest buyNowRequest = new TossPaymentConfirmRequest(
+                "paymentKey123",
+                "order123",
+                100000
+        );
+
+        TossPaymentConfirmResponse buyNowResponse = new TossPaymentConfirmResponse(
+                "DONE",
+                "paymentKey123",
+                "order123",
+                "2025-07-12",
+                "2025-07-12",
+                100000
+        );
+
+        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
+                .thenReturn(buyNowOrder);
+        when(namedLockProvider.getBottleLock(anyString()))
+                .thenReturn(namedLock);
+        when(tossApiClient.confirmPayment(buyNowRequest))
+                .thenReturn(buyNowResponse);
+        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
+                .thenReturn(payment);
+        when(bidRepository.findMaxBidPriceByAuctionId(1L))
+                .thenReturn(Optional.of(new BigDecimal("80000")));
+
+        doNothing().when(namedLock).lock();
+        doNothing().when(namedLock).unlock();
+
+        // when
+        assertDoesNotThrow(() -> paymentService.paymentConfirm(buyNowRequest));
+
+        // then
+        verify(bidRepository).findMaxBidPriceByAuctionId(1L);
+        verify(orderService).closeAuction(auction);
+        verify(paymentTransactionService, never()).updatePaymentStatusToFailed(any(), any());
+    }
+
+    @Test
+    @DisplayName("즉시 구매 결제 실패 - 현재 최고 입찰가가 즉시 구매 가격보다 높음")
+    void paymentConfirm_BuyNow_Failed_InvalidPrice() {
+        // given
+        TossPaymentConfirmRequest buyNowRequest = new TossPaymentConfirmRequest(
+                "paymentKey123",
+                "order123",
+                100000
+        );
+
+        TossPaymentConfirmResponse buyNowResponse = new TossPaymentConfirmResponse(
+                "DONE",
+                "paymentKey123",
+                "order123",
+                "2025-07-12",
+                "2025-07-12",
+                100000
+        );
+
+        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
+                .thenReturn(buyNowOrder);
+        when(namedLockProvider.getBottleLock(anyString()))
+                .thenReturn(namedLock);
+        when(tossApiClient.confirmPayment(buyNowRequest))
+                .thenReturn(buyNowResponse);
+        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
+                .thenReturn(payment);
+        when(bidRepository.findMaxBidPriceByAuctionId(1L))
+                .thenReturn(Optional.of(new BigDecimal("100000"))); // 같은 가격
+
+        doNothing().when(namedLock).lock();
+        doNothing().when(namedLock).unlock();
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.paymentConfirm(buyNowRequest))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("즉시 구매 가격이 현재 최고 입찰가보다 높아야 합니다.")
+                .extracting("status")
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+
+        verify(paymentTransactionService).updatePaymentStatusToFailed(payment, buyNowOrder);
+        verify(orderService, never()).closeAuction(auction);
     }
 
     @Test
@@ -143,12 +259,10 @@ class PaymentServiceTest {
     @Test
     @DisplayName("결제 승인 실패 - 토스 API 응답 상태가 실패")
     void paymentConfirm_PaymentStatusFailed() {
-        String LOCK_PREFIX = "auction-lock:";
-
         // given
         when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
                 .thenReturn(order);
-        when(namedLockProvider.getBottleLock(LOCK_PREFIX + order.getAuction().getAuctionId()))
+        when(namedLockProvider.getBottleLock(anyString()))
                 .thenReturn(namedLock);
         when(tossApiClient.confirmPayment(confirmRequest))
                 .thenReturn(failedResponse);
@@ -162,6 +276,8 @@ class PaymentServiceTest {
                 .hasMessage("결제 승인이 실패했습니다.")
                 .extracting("status")
                 .isEqualTo(HttpStatus.BAD_REQUEST);
+
+        verify(namedLock).unlock();
     }
 
     @Test
@@ -177,12 +293,87 @@ class PaymentServiceTest {
         when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
                 .thenReturn(order);
 
-
         // when & then
         assertThatThrownBy(() -> paymentService.paymentConfirm(invalidAmountRequest))
                 .isInstanceOf(GlobalException.class)
                 .hasMessage("결제 금액이 주문 금액과 일치하지 않습니다.")
                 .extracting("status")
                 .isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("결제 승인 실패 - 토스 API 호출 오류")
+    void paymentConfirm_TossApiError() {
+        // given
+        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
+                .thenReturn(order);
+        when(namedLockProvider.getBottleLock(anyString()))
+                .thenReturn(namedLock);
+        when(tossApiClient.confirmPayment(confirmRequest))
+                .thenThrow(FeignException.class);
+
+        doNothing().when(namedLock).lock();
+        doNothing().when(namedLock).unlock();
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("결제 처리 중 오류가 발생했습니다.")
+                .extracting("status")
+                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        verify(namedLock).unlock();
+    }
+
+    @Test
+    @DisplayName("결제 처리 중 예외 발생 시 결제 실패로 업데이트 및 락 해제")
+    void paymentConfirm_ExceptionHandling() {
+        // given
+        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
+                .thenReturn(order);
+        when(namedLockProvider.getBottleLock(anyString()))
+                .thenReturn(namedLock);
+        when(tossApiClient.confirmPayment(confirmRequest))
+                .thenReturn(successResponse);
+        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
+                .thenReturn(payment)
+                .thenThrow(ErrorCode.PAYMENT_CONFIRMATION_FAILED.toException());
+
+        doNothing().when(namedLock).lock();
+        doNothing().when(namedLock).unlock();
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.paymentConfirm(confirmRequest))
+                .isInstanceOf(GlobalException.class);
+
+        verify(paymentTransactionService).updatePaymentStatusToFailed(payment, order);
+        verify(namedLock).unlock();
+    }
+
+    @Test
+    @DisplayName("락 사용 검증 - 정확한 키로 락 획득")
+    void paymentConfirm_LockKeyVerification() {
+        // given
+        String expectedLockKey = "auction-lock:" + auction.getAuctionId();
+
+        when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
+                .thenReturn(order);
+        when(namedLockProvider.getBottleLock(expectedLockKey))
+                .thenReturn(namedLock);
+        when(tossApiClient.confirmPayment(confirmRequest))
+                .thenReturn(successResponse);
+        when(paymentTransactionService.savePayment(any(), any(), any(), any()))
+                .thenReturn(payment);
+
+        doNothing().when(namedLock).lock();
+        doNothing().when(namedLock).unlock();
+
+        // when
+        assertDoesNotThrow(() -> paymentService.paymentConfirm(confirmRequest));
+
+        // then
+        verify(namedLockProvider).getBottleLock(expectedLockKey);
+        verify(namedLock, times(1)).lock();
+        verify(namedLock, times(1)).unlock();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #19 

## 📝 작업 내용

결제 요청 → 주문/금액 검증 → 분산 락 획득 → 토스 API 호출 → 결제 저장

주문 타입별 처리
* 즉시 구매 (BUY_NOW)

추가 검증: 즉시 구매가 > 현재 최고 입찰가
성공 시: 경매 종료
실패 시: Payment/Order 상태를 FAILED로 변경 후 예외 발생

* 일반 경매 낙찰

경매 종료 처리

3. 상태 변경
```java
payment.statusFailed();  // SUCCESS → FAILED  
order.failed();         // PENDING → FAILED
```


```java
// 성공 시 (두 경우 모두)
// Payment: SUCCESS 유지
// Order: PENDING 유지  
// Auction: ACTIVE → CLOSED

```

## ✅ 피드백 반영사항
- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제)

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?