### PR TITLE
feat(20): 상품-경매 전체 조회 및 판매자 판매내역 조회 기능 구현 - 정미광

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -39,7 +39,7 @@ public class AuctionController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public List<AuctionListResponse> readAllAuctions() {
-        return auctionService.getAll();
+        return auctionService.findAll();
     }
 
     @Operation(summary = "경매등록")

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -2,6 +2,7 @@ package com.deal4u.fourplease.domain.auction.controller;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
+import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.member.repository.MemberRepository;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -32,6 +34,15 @@ public class AuctionController {
     private final AuctionService auctionService;
     private final MemberRepository memberRepository;
 
+    @Operation(summary = "전체 경매 조회")
+    @ApiResponse(responseCode = "200", description = "경매 목록 응답")
+    @ApiResponse(responseCode = "404", description = "경매를 찾을 수 없음")
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<AuctionListResponse> readAllAuctions() {
+        return auctionService.getAll();
+    }
+
     @Operation(summary = "경매등록")
     @ApiResponse(responseCode = "201", description = "경매 등록 성공")
     @ApiResponse(responseCode = "400", description = "invalid value")
@@ -39,6 +50,7 @@ public class AuctionController {
     @ResponseStatus(HttpStatus.CREATED)
     public void createAuction(
             @Valid @RequestBody AuctionCreateRequest request
+            // TODO: member 추후 수정 필요
     ) {
         auctionService.save(request, memberRepository.findAll().getFirst());
     }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -4,7 +4,6 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
-import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.member.repository.MemberRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -3,6 +3,7 @@ package com.deal4u.fourplease.domain.auction.controller;
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
+import com.deal4u.fourplease.domain.auction.dto.PageResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.member.repository.MemberRepository;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -38,8 +41,10 @@ public class AuctionController {
     @ApiResponse(responseCode = "404", description = "경매를 찾을 수 없음")
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<AuctionListResponse> readAllAuctions() {
-        return auctionService.findAll();
+    public PageResponse<AuctionListResponse> readAllAuctions(
+            @PageableDefault Pageable pageable
+    ) {
+        return auctionService.findAll(pageable);
     }
 
     @Operation(summary = "경매등록")

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -49,8 +49,8 @@ public class AuctionController {
     @ResponseStatus(HttpStatus.CREATED)
     public void createAuction(
             @Valid @RequestBody AuctionCreateRequest request
-            // TODO: member 추후 수정 필요
     ) {
+        // TODO: member 추후 수정 필요
         auctionService.save(request, memberRepository.findAll().getFirst());
     }
 

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
@@ -1,13 +1,15 @@
 package com.deal4u.fourplease.domain.auction.controller;
 
+import com.deal4u.fourplease.domain.auction.dto.PageResponse;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,10 +32,11 @@ public class SaleController {
     @ApiResponse(responseCode = "404", description = "경매를 찾을 수 없음")
     @GetMapping("/{sellerId}")
     @ResponseStatus(HttpStatus.OK)
-    public List<SellerSaleListResponse> getSales(
-            @PathVariable(name = "sellerId") @Positive Long sellerId
+    public PageResponse<SellerSaleListResponse> getSales(
+            @PathVariable(name = "sellerId") @Positive Long sellerId,
+            @PageableDefault Pageable pageable
     ) {
-        return auctionService.findSalesBySellerId(sellerId);
+        return auctionService.findSalesBySellerId(sellerId, pageable);
     }
 
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
@@ -1,0 +1,34 @@
+package com.deal4u.fourplease.domain.auction.controller;
+
+import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
+import com.deal4u.fourplease.domain.auction.service.AuctionService;
+import com.deal4u.fourplease.domain.bid.entity.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/sales")
+@RequiredArgsConstructor
+@Tag(name = "Sale", description = "판매내역 관리 API")
+public class SaleController {
+
+    private final AuctionService auctionService;
+
+    @GetMapping("/{sellerId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public List<SellerSaleListResponse> getSales(@PathVariable Long sellerId) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
@@ -33,7 +33,7 @@ public class SaleController {
     public List<SellerSaleListResponse> getSales(
             @PathVariable(name = "sellerId") @Positive Long sellerId
     ) {
-        return auctionService.getSalesBySellerId(sellerId);
+        return auctionService.findSalesBySellerId(sellerId);
     }
 
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/SaleController.java
@@ -2,12 +2,12 @@ package com.deal4u.fourplease.domain.auction.controller;
 
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
-import com.deal4u.fourplease.domain.bid.entity.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,10 +25,15 @@ public class SaleController {
 
     private final AuctionService auctionService;
 
+    @Operation(summary = "판매자 판매내역 조회")
+    @ApiResponse(responseCode = "200", description = "판매자 판매 내역 조회 성공")
+    @ApiResponse(responseCode = "404", description = "경매를 찾을 수 없음")
     @GetMapping("/{sellerId}")
-    @ResponseStatus(HttpStatus.CREATED)
-    public List<SellerSaleListResponse> getSales(@PathVariable Long sellerId) {
-        return null;
+    @ResponseStatus(HttpStatus.OK)
+    public List<SellerSaleListResponse> getSales(
+            @PathVariable(name = "sellerId") @Positive Long sellerId
+    ) {
+        return auctionService.getSalesBySellerId(sellerId);
     }
 
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionDetailResponse.java
@@ -33,15 +33,15 @@ public record AuctionDetailResponse(
 ) {
 
     public static AuctionDetailResponse toAuctionDetailResponse(
-            List<Long> bidList,
+            BidSummaryDto bidSummaryDto,
             Auction auction,
             List<String> productImageUrls
     ) {
         Product product = auction.getProduct();
         return new AuctionDetailResponse(
-                BigDecimal.valueOf(bidList.getFirst()),
+                bidSummaryDto.maxPrice(),
                 auction.getInstantBidPrice(),
-                bidList.size(),
+                bidSummaryDto.bidCount(),
                 auction.getStartingPrice(),
                 product.getName(),
                 product.getCategory().getCategoryId(),

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionDetailResponse.java
@@ -9,33 +9,28 @@ import java.util.List;
 public record AuctionDetailResponse(
 
         BigDecimal highestBidPrice,
-
         BigDecimal instantBidPrice,
 
-        Integer bidCount,
+        int bidCount,
 
         BigDecimal startingPrice,
 
         String productName,
-
-        Long categoryId,
-
+        long categoryId,
         String categoryName,
-
         String description,
 
         LocalDateTime endTime,
 
         String thumbnailUrl,
-
         List<String> imageUrls
 
 ) {
 
     public static AuctionDetailResponse toAuctionDetailResponse(
-            BidSummaryDto bidSummaryDto,
             Auction auction,
-            List<String> productImageUrls
+            List<String> productImageUrls,
+            BidSummaryDto bidSummaryDto
     ) {
         Product product = auction.getProduct();
         return new AuctionDetailResponse(

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionListResponse.java
@@ -1,0 +1,4 @@
+package com.deal4u.fourplease.domain.auction.dto;
+
+public record AuctionListResponse() {
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionListResponse.java
@@ -1,4 +1,45 @@
 package com.deal4u.fourplease.domain.auction.dto;
 
-public record AuctionListResponse() {
+import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.Category;
+import com.deal4u.fourplease.domain.auction.entity.Product;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record AuctionListResponse(
+        long auctionId,
+
+        String thumbnailUrl,
+        // TODO: Category 확인 필요
+        CategoryDto category,
+        String name,
+
+        BigDecimal maxPrice,
+        BigDecimal instantPrice,
+
+        int bidCount,
+
+        LocalDateTime endTime,
+
+        boolean isWishlist
+) {
+    public static AuctionListResponse toAuctionListResponse(
+            Auction auction,
+            BidSummaryDto bidSummaryDto,
+            // TODO: wishlist 개발 후 수정 필요
+            boolean isWishlist
+    ) {
+        Product product = auction.getProduct();
+        return new AuctionListResponse(
+                auction.getAuctionId(),
+                product.getThumbnailUrl(),
+                CategoryDto.toCategoryDto(product.getCategory()),
+                product.getName(),
+                bidSummaryDto.maxPrice(),
+                auction.getInstantBidPrice(),
+                bidSummaryDto.bidCount(),
+                auction.getDuration().getEndTime(),
+                isWishlist
+        );
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/BidSummaryDto.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/BidSummaryDto.java
@@ -1,4 +1,16 @@
 package com.deal4u.fourplease.domain.auction.dto;
 
-public record BidSummaryDto() {
+import java.math.BigDecimal;
+import java.util.List;
+
+public record BidSummaryDto(
+        BigDecimal maxPrice,
+        int bidCount
+) {
+    public static BidSummaryDto toBidSummaryDto(List<Long> bidList) {
+        if (bidList.isEmpty()) {
+            return new BidSummaryDto(BigDecimal.ZERO, 0);
+        }
+        return new BidSummaryDto(BigDecimal.valueOf(bidList.getFirst()), bidList.size());
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/BidSummaryDto.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/BidSummaryDto.java
@@ -1,0 +1,4 @@
+package com.deal4u.fourplease.domain.auction.dto;
+
+public record BidSummaryDto() {
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/BidSummaryDto.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/BidSummaryDto.java
@@ -7,10 +7,10 @@ public record BidSummaryDto(
         BigDecimal maxPrice,
         int bidCount
 ) {
-    public static BidSummaryDto toBidSummaryDto(List<Long> bidList) {
+    public static BidSummaryDto toBidSummaryDto(List<BigDecimal> bidList) {
         if (bidList.isEmpty()) {
             return new BidSummaryDto(BigDecimal.ZERO, 0);
         }
-        return new BidSummaryDto(BigDecimal.valueOf(bidList.getFirst()), bidList.size());
+        return new BidSummaryDto(bidList.getFirst(), bidList.size());
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/CategoryDto.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/CategoryDto.java
@@ -1,0 +1,4 @@
+package com.deal4u.fourplease.domain.auction.dto;
+
+public record CategoryDto() {
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/CategoryDto.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/CategoryDto.java
@@ -1,4 +1,15 @@
 package com.deal4u.fourplease.domain.auction.dto;
 
-public record CategoryDto() {
+import com.deal4u.fourplease.domain.auction.entity.Category;
+
+public record CategoryDto(
+        Long categoryId,
+        String name
+) {
+    public static CategoryDto toCategoryDto(Category category) {
+        return new CategoryDto(
+                category.getCategoryId(),
+                category.getName()
+        );
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/PageResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/PageResponse.java
@@ -1,0 +1,31 @@
+package com.deal4u.fourplease.domain.auction.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageResponse<T> {
+
+    private List<T> content;
+    private int page;
+    private int size;
+    private int totalPages;
+    private long totalElements;
+
+    public static <T> PageResponse<T> fromPage(Page<T> pageData) {
+        return PageResponse.<T>builder()
+                .content(pageData.getContent())
+                .page(pageData.getNumber())
+                .size(pageData.getSize())
+                .totalPages(pageData.getTotalPages())
+                .totalElements(pageData.getTotalElements())
+                .build();
+    }
+
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/ProductCreateDto.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/ProductCreateDto.java
@@ -15,38 +15,17 @@ import java.util.List;
 
 public record ProductCreateDto(
 
-        @NotNull(message = "판매자 정보를 입력해 주세요.")
         Member member,
 
-        @NotBlank(message = "상품 이름을 입력해 주세요.")
-        @Size(min = 1, max = 20, message = "상품 이름은 1자 이상 20자 이하로 입력해주세요.")
         String name,
-
-        @NotBlank(message = "상품 설명을 입력해 주세요.")
-        @Size(min = 1, max = 1000, message = "상품 설명은 1자 이상 1000자 이하로 입력해주세요.")
         String description,
-
-        @NotBlank(message = "상품 썸네일 이미지를 입력해 주세요.")
         String thumbnailUrl,
-
-        @NotEmpty(message = "상품 상세 이미지를 입력해 주세요.")
         List<String> imageUrls,
-
-        @NotNull(message = "카테고리 ID를 입력해 주세요.")
         Long categoryId,
 
-        @NotBlank(message = "주소를 입력해 주세요.")
         String address,
-
-        @NotBlank(message = "상세 주소를 입력해 주세요.")
         String addressDetail,
-
-        @NotBlank(message = "우편 번호를 입력해 주세요.")
         String zipCode,
-
-        @NotBlank(message = "휴대폰 번호를 입력해 주세요.")
-        @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$",
-                message = "휴대폰 번호 형식이 올바르지 않습니다.")
         String phone
 
 ) {

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
@@ -1,4 +1,16 @@
 package com.deal4u.fourplease.domain.auction.dto;
 
-public record SellerSaleListResponse() {
+import java.math.BigDecimal;
+
+public record SellerSaleListResponse(
+        String thumbnailUrl,
+        String name,
+        BigDecimal maxPrice,
+        BigDecimal startBidPrice,
+        String description,
+        Integer salesCount,
+        Integer bidCount,
+        String status
+) {
+
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
@@ -23,10 +23,10 @@ public record SellerSaleListResponse(
 
     public static SellerSaleListResponse toSellerSaleListResponse(
             Auction auction,
-            Product product,
             BidSummaryDto bidSummaryDto,
             SaleAuctionStatus status
     ) {
+        Product product = auction.getProduct();
         return new SellerSaleListResponse(
                 auction.getAuctionId(),
                 product.getThumbnailUrl(),

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
@@ -5,11 +5,16 @@ import java.math.BigDecimal;
 public record SellerSaleListResponse(
         String thumbnailUrl,
         String name,
+
         BigDecimal maxPrice,
         BigDecimal startBidPrice,
+
         String description,
-        Integer salesCount,
-        Integer bidCount,
+
+        int salesCount,
+
+        int bidCount,
+
         String status
 ) {
 

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
@@ -1,8 +1,13 @@
 package com.deal4u.fourplease.domain.auction.dto;
 
+import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.Product;
+import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
 import java.math.BigDecimal;
 
 public record SellerSaleListResponse(
+        long auctionId,
+
         String thumbnailUrl,
         String name,
 
@@ -11,11 +16,26 @@ public record SellerSaleListResponse(
 
         String description,
 
-        int salesCount,
-
         int bidCount,
 
         String status
 ) {
 
+    public static SellerSaleListResponse toSellerSaleListResponse(
+            Auction auction,
+            Product product,
+            BidSummaryDto bidSummaryDto,
+            SaleAuctionStatus status
+    ) {
+        return new SellerSaleListResponse(
+                auction.getAuctionId(),
+                product.getThumbnailUrl(),
+                product.getName(),
+                bidSummaryDto.maxPrice(),
+                auction.getStartingPrice(),
+                product.getDescription(),
+                bidSummaryDto.bidCount(),
+                status.toString()
+        );
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
@@ -1,0 +1,4 @@
+package com.deal4u.fourplease.domain.auction.dto;
+
+public record SellerSaleListResponse() {
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/entity/SaleAuctionStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/entity/SaleAuctionStatus.java
@@ -1,5 +1,5 @@
 package com.deal4u.fourplease.domain.auction.entity;
 
 public enum SaleAuctionStatus {
-    OPEN, PENDING, SUCCESS, REJECT, INTRANSIT ,DELIVERED, FAIL
+    OPEN, PENDING, SUCCESS, REJECT, INTRANSIT, DELIVERED, FAIL
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/entity/SaleAuctionStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/entity/SaleAuctionStatus.java
@@ -1,0 +1,5 @@
+package com.deal4u.fourplease.domain.auction.entity;
+
+public enum SaleAuctionStatus {
+    OPEN, PENDING, SUCCESS, REJECT, INTRANSIT ,DELIVERED, FAIL
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/mapper/ProductImageMapper.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/mapper/ProductImageMapper.java
@@ -1,11 +1,7 @@
 package com.deal4u.fourplease.domain.auction.mapper;
 
-import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
-import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.entity.ProductImage;
-import java.math.BigDecimal;
-import java.util.List;
 
 public class ProductImageMapper {
 

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -1,6 +1,7 @@
 package com.deal4u.fourplease.domain.auction.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,11 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "AND a.deleted = false "
             + "AND a.status = 'OPEN'")
     Optional<Auction> findByAuctionIdAndDeletedFalseAndStatusOpen(Long auctionId);
+
+    @Query("select a "
+            + "from Auction a "
+            + "join fetch a.product p "
+            + "where p.productId in :productIdList "
+            + "and a.deleted = false")
+    List<Auction> findAllByProductId(@Param("productIdList") List<Long> productIdList);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -31,4 +31,10 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             @Param("productIdList") List<Long> productIdList,
             Pageable pageable
     );
+
+    @Query("select a "
+            + "from Auction a "
+            + "where a.deleted = false "
+            + "order by a.createdAt desc")
+    Page<Auction> findAll(Pageable pageable);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -3,6 +3,8 @@ package com.deal4u.fourplease.domain.auction.repository;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,6 +25,10 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "from Auction a "
             + "join fetch a.product p "
             + "where p.productId in :productIdList "
-            + "and a.deleted = false")
-    List<Auction> findAllByProductId(@Param("productIdList") List<Long> productIdList);
+            + "and a.deleted = false "
+            + "order by a.createdAt desc")
+    Page<Auction> findAllByProductIdIn(
+            @Param("productIdList") List<Long> productIdList,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -11,7 +11,6 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
     @Query("select a from Auction a join fetch a.product where a.auctionId = :auctionId")
     Optional<Auction> findByIdWithProduct(@Param("auctionId") Long auctionId);
 
-
     @Query("SELECT a "
             + "FROM Auction a "
             + "WHERE a.auctionId = :auctionId "

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/ProductRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/ProductRepository.java
@@ -1,8 +1,15 @@
 package com.deal4u.fourplease.domain.auction.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Product;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    @Query("select p from Product p "
+            + "where p.seller.member.memberId = :sellerId "
+            + "and p.deleted = false")
+    List<Product> findBySellerId(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/package-info.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package com.deal4u.fourplease.domain.auction.repository;
+
+import org.springframework.lang.NonNullApi;

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -2,6 +2,8 @@ package com.deal4u.fourplease.domain.auction.service;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
+import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
+import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.Product;
@@ -10,6 +12,7 @@ import com.deal4u.fourplease.domain.bid.repository.BidRepository;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.ErrorCode;
 import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -48,7 +51,12 @@ public class AuctionService {
         List<String> productImageUrls = productImageService.getByProduct(product)
                 .toProductImageUrlList();
 
-        return AuctionDetailResponse.toAuctionDetailResponse(bidList, auction, productImageUrls);
+        BidSummaryDto bidSummaryDto = BidSummaryDto.toBidSummaryDto(bidList);
+        return AuctionDetailResponse.toAuctionDetailResponse(
+                bidSummaryDto,
+                auction,
+                productImageUrls
+        );
     }
 
     @Transactional

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -68,7 +68,7 @@ public class AuctionService {
     }
 
     @Transactional(readOnly = true)
-    public List<SellerSaleListResponse> getSalesBySellerId(Long sellerId) {
+    public List<SellerSaleListResponse> findSalesBySellerId(Long sellerId) {
         List<Product> productList = productService.getProductListBySellerId(sellerId);
 
         List<Long> productIdList = productList.stream()

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -64,10 +64,13 @@ public class AuctionService {
     }
 
     @Transactional(readOnly = true)
-    public List<AuctionListResponse> findAll() {
-        List<Auction> auctionList = auctionRepository.findAll();
+    public PageResponse<AuctionListResponse> findAll(Pageable pageable) {
+        Page<Auction> auctionPage = auctionRepository.findAll(pageable);
 
-        return auctionSupportService.getAuctionListResponses(auctionList);
+        Page<AuctionListResponse> auctionListResponsePage = auctionSupportService
+                .getAuctionListResponses(auctionPage);
+
+        return PageResponse.fromPage(auctionListResponsePage);
     }
 
     @Transactional(readOnly = true)
@@ -83,7 +86,7 @@ public class AuctionService {
 
         Page<Auction> auctionPage = auctionRepository.findAllByProductIdIn(productIdList, pageable);
 
-        Page<SellerSaleListResponse> SellerSaleListResponsePage = auctionPage
+        Page<SellerSaleListResponse> sellerSaleListResponsePage = auctionPage
                 .map(auction -> {
                     BidSummaryDto bidSummaryDto = auctionSupportService
                             .getBidSummaryDto(auction.getAuctionId());
@@ -94,7 +97,7 @@ public class AuctionService {
                     );
                 });
 
-        return PageResponse.fromPage(SellerSaleListResponsePage);
+        return PageResponse.fromPage(sellerSaleListResponsePage);
     }
 
     private List<String> getProductImageUrlList(Product product) {

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -5,14 +5,12 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
+import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
-import com.deal4u.fourplease.domain.bid.repository.BidRepository;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.ErrorCode;
-import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,8 +22,9 @@ public class AuctionService {
 
     private final AuctionRepository auctionRepository;
     private final ProductService productService;
-    private final BidRepository bidRepository;
     private final ProductImageService productImageService;
+
+    private final AuctionSupportService auctionSupportService;
 
     @Transactional
     public void save(AuctionCreateRequest request, Member member) {
@@ -38,7 +37,7 @@ public class AuctionService {
 
     @Transactional(readOnly = true)
     public AuctionDetailResponse getByAuctionId(Long auctionId) {
-        BidSummaryDto bidSummaryDto = getBidSummaryDto(auctionId);
+        BidSummaryDto bidSummaryDto = auctionSupportService.getBidSummaryDto(auctionId);
 
         Auction auction = auctionRepository.findByIdWithProduct(auctionId)
                 .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
@@ -63,34 +62,37 @@ public class AuctionService {
 
     @Transactional(readOnly = true)
     public List<AuctionListResponse> findAll() {
-        List<AuctionListResponse> auctionListResponseList = new ArrayList<>();
-
         List<Auction> auctionList = auctionRepository.findAll();
 
-        for (Auction auction : auctionList) {
-            BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());
-
-            auctionListResponseList.add(
-                    AuctionListResponse.toAuctionListResponse(
-                            auction,
-                            bidSummaryDto,
-                            false
-                    )
-            );
-        }
-
-        return auctionListResponseList;
+        return auctionSupportService.getAuctionListResponses(auctionList);
     }
 
-    private BidSummaryDto getBidSummaryDto(Long auctionId) {
-        List<BigDecimal> bidList = bidRepository.findPricesByAuctionIdOrderByPriceDesc(
-                auctionId
-        );
-        return BidSummaryDto.toBidSummaryDto(bidList);
+    @Transactional(readOnly = true)
+    public List<SellerSaleListResponse> getSalesBySellerId(Long sellerId) {
+        List<Product> productList = productService.getProductListBySellerId(sellerId);
+
+        List<Long> productIdList = productList.stream()
+                .map(Product::getProductId)
+                .toList();
+
+        List<Auction> auctionList = auctionRepository.findAllByProductId(productIdList);
+
+        return auctionList.stream()
+                .map(auction -> {
+                    BidSummaryDto bidSummaryDto = auctionSupportService
+                            .getBidSummaryDto(auction.getAuctionId());
+                    return SellerSaleListResponse.toSellerSaleListResponse(
+                            auction,
+                            bidSummaryDto,
+                            auctionSupportService.getSaleAuctionStatus(auction)
+                    );
+                })
+                .toList();
     }
 
     private List<String> getProductImageUrlList(Product product) {
         return productImageService.getByProduct(product)
                 .toProductImageUrlList();
     }
+
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -11,8 +11,8 @@ import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.repository.BidRepository;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.ErrorCode;
-import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AuctionService {
 
     private final AuctionRepository auctionRepository;
@@ -30,41 +29,68 @@ public class AuctionService {
 
     @Transactional
     public void save(AuctionCreateRequest request, Member member) {
-
         ProductCreateDto productCreateDto = request.toProductCreateDto(member);
         Product product = productService.save(productCreateDto);
 
         Auction auction = request.toEntity(product);
         auctionRepository.save(auction);
-
     }
 
-    public AuctionDetailResponse getByAuctionId(@Positive Long auctionId) {
-        // TODO: Long -> BigDecimal로 변경 예정
-        List<Long> bidList = bidRepository.findPricesByAuctionIdOrderByPriceDesc(auctionId);
+    @Transactional(readOnly = true)
+    public AuctionDetailResponse getByAuctionId(Long auctionId) {
+        BidSummaryDto bidSummaryDto = getBidSummaryDto(auctionId);
 
         Auction auction = auctionRepository.findByIdWithProduct(auctionId)
                 .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
 
-        Product product = auction.getProduct();
+        List<String> productImageUrlList = getProductImageUrlList(auction.getProduct());
 
-        List<String> productImageUrls = productImageService.getByProduct(product)
-                .toProductImageUrlList();
-
-        BidSummaryDto bidSummaryDto = BidSummaryDto.toBidSummaryDto(bidList);
         return AuctionDetailResponse.toAuctionDetailResponse(
-                bidSummaryDto,
                 auction,
-                productImageUrls
+                productImageUrlList,
+                bidSummaryDto
         );
     }
 
     @Transactional
-    public void deleteByAuctionId(@Positive Long auctionId) {
+    public void deleteByAuctionId(Long auctionId) {
         Auction targetAuction = auctionRepository.findByIdWithProduct(auctionId)
                 .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
 
         productService.deleteProduct(targetAuction.getProduct());
         targetAuction.delete();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AuctionListResponse> findAll() {
+        List<AuctionListResponse> auctionListResponseList = new ArrayList<>();
+
+        List<Auction> auctionList = auctionRepository.findAll();
+
+        for (Auction auction : auctionList) {
+            BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());
+
+            auctionListResponseList.add(
+                    AuctionListResponse.toAuctionListResponse(
+                            auction,
+                            bidSummaryDto,
+                            false
+                    )
+            );
+        }
+
+        return auctionListResponseList;
+    }
+
+    private BidSummaryDto getBidSummaryDto(Long auctionId) {
+        List<BigDecimal> bidList = bidRepository.findPricesByAuctionIdOrderByPriceDesc(
+                auctionId
+        );
+        return BidSummaryDto.toBidSummaryDto(bidList);
+    }
+
+    private List<String> getProductImageUrlList(Product product) {
+        return productImageService.getByProduct(product)
+                .toProductImageUrlList();
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -1,0 +1,102 @@
+package com.deal4u.fourplease.domain.auction.service;
+
+import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
+import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
+import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
+import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
+import com.deal4u.fourplease.domain.bid.repository.BidRepository;
+import com.deal4u.fourplease.domain.settlement.repository.SettlementRepository;
+import com.deal4u.fourplease.domain.shipment.repository.ShipmentRepository;
+import com.deal4u.fourplease.global.exception.ErrorCode;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionSupportService {
+
+    private final BidRepository bidRepository;
+    private final SettlementRepository settlementRepository;
+    private final ShipmentRepository shipmentRepository;
+
+    public BidSummaryDto getBidSummaryDto(Long auctionId) {
+        List<BigDecimal> bidList = bidRepository.findPricesByAuctionIdOrderByPriceDesc(
+                auctionId
+        );
+        return BidSummaryDto.toBidSummaryDto(bidList);
+    }
+
+    public List<AuctionListResponse> getAuctionListResponses(List<Auction> auctionList) {
+        List<AuctionListResponse> auctionListResponseList = new ArrayList<>();
+        for (Auction auction : auctionList) {
+            BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());
+
+            auctionListResponseList.add(
+                    AuctionListResponse.toAuctionListResponse(
+                            auction,
+                            bidSummaryDto,
+                            // TODO: wishList 개발 후 수정 필요
+                            false
+                    )
+            );
+        }
+
+        return auctionList.stream()
+                .map(auction -> {
+                    BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());
+                    return AuctionListResponse.toAuctionListResponse(
+                            auction,
+                            bidSummaryDto,
+                            // TODO: wishList 개발 후 수정 필요
+                            false
+                    );
+                })
+                .toList();
+    }
+
+    // TODO: 추후 개선 필요
+    public SaleAuctionStatus getSaleAuctionStatus(Auction auction) {
+        if (auction.getStatus().equals(AuctionStatus.OPEN)) {
+            return SaleAuctionStatus.OPEN;
+        }
+        if (auction.getStatus().equals(AuctionStatus.FAIL)) {
+            return SaleAuctionStatus.FAIL;
+        }
+        // AuctionStatus.CLOSE
+        return getSettlementStatus(auction.getAuctionId());
+    }
+
+    private SaleAuctionStatus getSettlementStatus(Long auctionId) {
+        String settlementStatus = settlementRepository.getSettlementStatusByAuctionId(auctionId)
+                .toString();
+        if (settlementStatus.equals("PENDING")) {
+            return SaleAuctionStatus.PENDING;
+        }
+        if (settlementStatus.equals("SUCCESS")) {
+            return SaleAuctionStatus.SUCCESS;
+        }
+        if (settlementStatus.equals("REJECTED")) {
+            return SaleAuctionStatus.REJECT;
+        }
+
+        return getShipmentStatus(auctionId);
+    }
+
+    private SaleAuctionStatus getShipmentStatus(Long auctionId) {
+        String shipmentStatus = shipmentRepository.getShipmentStatusByAuctionId(auctionId)
+                .toString();
+        if (shipmentStatus.equals("INTRANSIT")) {
+            return SaleAuctionStatus.INTRANSIT;
+        }
+        if (shipmentStatus.equals("DELIVERED")) {
+            return SaleAuctionStatus.DELIVERED;
+        }
+        throw ErrorCode.STATUS_NOT_FOUND.toException();
+    }
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -10,7 +10,6 @@ import com.deal4u.fourplease.domain.settlement.repository.SettlementRepository;
 import com.deal4u.fourplease.domain.shipment.repository.ShipmentRepository;
 import com.deal4u.fourplease.global.exception.ErrorCode;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,20 +32,6 @@ public class AuctionSupportService {
     }
 
     public List<AuctionListResponse> getAuctionListResponses(List<Auction> auctionList) {
-        List<AuctionListResponse> auctionListResponseList = new ArrayList<>();
-        for (Auction auction : auctionList) {
-            BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());
-
-            auctionListResponseList.add(
-                    AuctionListResponse.toAuctionListResponse(
-                            auction,
-                            bidSummaryDto,
-                            // TODO: wishList 개발 후 수정 필요
-                            false
-                    )
-            );
-        }
-
         return auctionList.stream()
                 .map(auction -> {
                     BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -12,6 +12,7 @@ import com.deal4u.fourplease.global.exception.ErrorCode;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,8 +32,8 @@ public class AuctionSupportService {
         return BidSummaryDto.toBidSummaryDto(bidList);
     }
 
-    public List<AuctionListResponse> getAuctionListResponses(List<Auction> auctionList) {
-        return auctionList.stream()
+    public Page<AuctionListResponse> getAuctionListResponses(Page<Auction> auctionPage) {
+        return auctionPage
                 .map(auction -> {
                     BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());
                     return AuctionListResponse.toAuctionListResponse(
@@ -41,8 +42,7 @@ public class AuctionSupportService {
                             // TODO: wishList 개발 후 수정 필요
                             false
                     );
-                })
-                .toList();
+                });
     }
 
     // TODO: 추후 개선 필요

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/ProductService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/ProductService.java
@@ -1,11 +1,16 @@
 package com.deal4u.fourplease.domain.auction.service;
 
+import static com.deal4u.fourplease.domain.auction.validator.Validator.validateListNotEmpty;
+
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
+import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.Category;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.repository.CategoryRepository;
 import com.deal4u.fourplease.domain.auction.repository.ProductRepository;
 import com.deal4u.fourplease.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,5 +39,11 @@ public class ProductService {
     public void deleteProduct(Product targetProduct) {
         productImageService.deleteProductImage(targetProduct);
         targetProduct.delete();
+    }
+
+    public List<Product> getProductListBySellerId(Long sellerId) {
+        List<Product> productList = productRepository.findBySellerId(sellerId);
+        validateListNotEmpty(productList);
+        return productList;
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/repository/BidRepository.java
@@ -4,6 +4,7 @@ import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.entity.Bid;
 import com.deal4u.fourplease.domain.bid.entity.Bidder;
 import com.deal4u.fourplease.domain.member.entity.Member;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -20,7 +21,7 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
     @Query("select b.price from Bid b where b.deleted = false "
             + "AND b.auction.auctionId = :auctionId order by b.price desc")
-    List<Long> findPricesByAuctionIdOrderByPriceDesc(@Param("auctionId") Long auctionId);
+    List<BigDecimal> findPricesByAuctionIdOrderByPriceDesc(@Param("auctionId") Long auctionId);
 
     @Query("SELECT b FROM Bid b "
             + "WHERE b.auction.auctionId = :auctionId "

--- a/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/settlement/repository/SettlementRepository.java
@@ -4,9 +4,18 @@ import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.entity.Bidder;
 import com.deal4u.fourplease.domain.settlement.entity.Settlement;
 import com.deal4u.fourplease.domain.settlement.entity.SettlementStatus;
+import com.deal4u.fourplease.domain.shipment.entity.ShipmentStatus;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface SettlementRepository extends CrudRepository<Settlement, Long> {
     boolean existsByAuctionAndBidderAndStatus(Auction auction, Bidder bidder,
                                               SettlementStatus status);
+
+
+    @Query("select s.status "
+            + "from Settlement s "
+            + "where s.auction.auctionId = :auctionId")
+    SettlementStatus getSettlementStatusByAuctionId(Long auctionId);
+
 }

--- a/src/main/java/com/deal4u/fourplease/domain/shipment/repository/ShipmentRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/shipment/repository/ShipmentRepository.java
@@ -1,0 +1,15 @@
+package com.deal4u.fourplease.domain.shipment.repository;
+
+import com.deal4u.fourplease.domain.shipment.entity.Shipment;
+import com.deal4u.fourplease.domain.shipment.entity.ShipmentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ShipmentRepository extends JpaRepository<Shipment, Long> {
+
+    @Query("select s.status "
+            + "from Shipment s "
+            + "where s.auction.auctionId = :auctionId")
+    ShipmentStatus getShipmentStatusByAuctionId(Long auctionId);
+
+}

--- a/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
+++ b/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
@@ -42,8 +42,11 @@ public enum ErrorCode {
 
     BIDPERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "경매 기간을 찾을 수 없습니다."),
 
-    BID_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "경매 기간을 찾을 수 없습니다.");
+    BID_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "경매 기간을 찾을 수 없습니다."),
 
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+
+    STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 상태를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -107,6 +107,7 @@ class AuctionControllerTests {
         mockMvc.perform(
                         get("/api/v1/auctions")
                 ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(resp.size()))
                 .andExpect(jsonPath("$[0].name").value(resp.get(0).name()))
                 .andExpect(jsonPath("$[1].name").value(resp.get(1).name()))
                 .andExpect(jsonPath("$[2].name").value(resp.get(2).name()))

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -2,7 +2,7 @@ package com.deal4u.fourplease.domain.auction.controller;
 
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionCreateRequest;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionDetailResponse;
-import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionListResponseList;
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionListResponsePageResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
+import com.deal4u.fourplease.domain.auction.dto.PageResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.member.repository.MemberRepository;
@@ -26,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -100,17 +103,26 @@ class AuctionControllerTests {
     @DisplayName("GET /api/v1/auctions가 성공하면 전체 경매 목록과 200을 반환한다")
     void readAllAuctionsShouldReturn200() throws Exception {
 
-        List<AuctionListResponse> resp = genAuctionListResponseList();
+        Pageable pageable = PageRequest.of(0, 20);
+        PageResponse<AuctionListResponse> resp = genAuctionListResponsePageResponse();
 
-        when(auctionService.findAll()).thenReturn(resp);
+        when(auctionService.findAll(pageable)).thenReturn(resp);
 
         mockMvc.perform(
                         get("/api/v1/auctions")
+                                .param("page", "0")
+                                .param("size", "20")
                 ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(resp.size()))
-                .andExpect(jsonPath("$[0].name").value(resp.get(0).name()))
-                .andExpect(jsonPath("$[1].name").value(resp.get(1).name()))
-                .andExpect(jsonPath("$[2].name").value(resp.get(2).name()))
+                .andExpect(jsonPath("$.content[0].name")
+                        .value(resp.getContent().get(0).name()))
+                .andExpect(jsonPath("$.content[1].name")
+                        .value(resp.getContent().get(1).name()))
+                .andExpect(jsonPath("$.content[2].name")
+                        .value(resp.getContent().get(2).name()))
+                .andExpect(jsonPath("$.totalElements").value(resp.getTotalElements()))
+                .andExpect(jsonPath("$.totalPages").value(resp.getTotalPages()))
+                .andExpect(jsonPath("$.page").value(resp.getPage()))
+                .andExpect(jsonPath("$.size").value(resp.getSize()))
                 .andDo(print());
 
     }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -2,6 +2,7 @@ package com.deal4u.fourplease.domain.auction.controller;
 
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionCreateRequest;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionDetailResponse;
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionListResponseList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
+import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.member.repository.MemberRepository;
@@ -48,7 +50,9 @@ class AuctionControllerTests {
     void createAuctionShouldReturn201() throws Exception {
 
         AuctionCreateRequest req = genAuctionCreateRequest();
+
         when(memberRepository.findAll()).thenReturn(List.of(Mockito.mock(Member.class)));
+
         mockMvc.perform(
                         post("/api/v1/auctions")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -90,5 +94,24 @@ class AuctionControllerTests {
                 .andDo(print());
 
         verify(auctionService).deleteByAuctionId(auctionId);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/auctions가 성공하면 전체 경매 목록과 200을 반환한다")
+    void readAllAuctionsShouldReturn200() throws Exception {
+
+        List<AuctionListResponse> resp = genAuctionListResponseList();
+
+        when(auctionService.getAll()).thenReturn(resp);
+
+        mockMvc.perform(
+                        get("/api/v1/auctions")
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value(resp.get(0).name()))
+                .andExpect(jsonPath("$[1].name").value(resp.get(1).name()))
+                .andExpect(jsonPath("$[2].name").value(resp.get(2).name()))
+                .andDo(print());
+
+
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -102,7 +102,7 @@ class AuctionControllerTests {
 
         List<AuctionListResponse> resp = genAuctionListResponseList();
 
-        when(auctionService.getAll()).thenReturn(resp);
+        when(auctionService.findAll()).thenReturn(resp);
 
         mockMvc.perform(
                         get("/api/v1/auctions")
@@ -111,7 +111,6 @@ class AuctionControllerTests {
                 .andExpect(jsonPath("$[1].name").value(resp.get(1).name()))
                 .andExpect(jsonPath("$[2].name").value(resp.get(2).name()))
                 .andDo(print());
-
 
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -45,7 +45,7 @@ class AuctionControllerTests {
 
     @Test
     @DisplayName("POST /api/v1/auctions가 성공하면 경매를 등록한 후 201을 반환한다")
-    void create_auction_should_return_201() throws Exception {
+    void createAuctionShouldReturn201() throws Exception {
 
         AuctionCreateRequest req = genAuctionCreateRequest();
         when(memberRepository.findAll()).thenReturn(List.of(Mockito.mock(Member.class)));
@@ -62,7 +62,7 @@ class AuctionControllerTests {
 
     @Test
     @DisplayName("GET /api/v1/auctions/{auctionId}/description이 성공하면 Id의 경매 정보와 200을 반환한다")
-    void read_auction_should_return_200() throws Exception {
+    void readAuctionShouldReturn200() throws Exception {
 
         Long auctionId = 1L;
         AuctionDetailResponse resp = genAuctionDetailResponse();
@@ -80,7 +80,7 @@ class AuctionControllerTests {
 
     @Test
     @DisplayName("DELETE /api/v1/auctions/{auctionId}가 성공하면 soft delete 후 204를 반환한다")
-    void delete_auction_should_return_204() throws Exception {
+    void deleteAuctionShouldReturn204() throws Exception {
 
         Long auctionId = 1L;
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/SaleControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/SaleControllerTests.java
@@ -1,19 +1,21 @@
 package com.deal4u.fourplease.domain.auction.controller;
 
-import static com.deal4u.fourplease.domain.auction.util.TestUtils.genSellerSaleListResponseList;
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genSellerSaleListResponsePageResponse;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.deal4u.fourplease.domain.auction.dto.PageResponse;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -31,17 +33,27 @@ class SaleControllerTests {
     void getSalesShouldReturn200() throws Exception {
 
         Long sellerId = 1L;
+        Pageable pageable = PageRequest.of(0, 20);
 
-        List<SellerSaleListResponse> resp = genSellerSaleListResponseList();
+        PageResponse<SellerSaleListResponse> resp = genSellerSaleListResponsePageResponse();
 
-        when(auctionService.findSalesBySellerId(sellerId)).thenReturn(resp);
+        when(auctionService.findSalesBySellerId(sellerId, pageable)).thenReturn(resp);
 
         mockMvc.perform(
                 get("/api/v1/sales/{sellerId}", sellerId)
+                        .param("page", "0")
+                        .param("size", "20")
         ).andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value(resp.get(0).name()))
-                .andExpect(jsonPath("$[1].name").value(resp.get(1).name()))
-                .andExpect(jsonPath("$[2].name").value(resp.get(2).name()))
+                .andExpect(jsonPath("$.content[0].name")
+                        .value(resp.getContent().get(0).name()))
+                .andExpect(jsonPath("$.content[1].name")
+                        .value(resp.getContent().get(1).name()))
+                .andExpect(jsonPath("$.content[2].name")
+                        .value(resp.getContent().get(2).name()))
+                .andExpect(jsonPath("$.totalElements").value(resp.getTotalElements()))
+                .andExpect(jsonPath("$.totalPages").value(resp.getTotalPages()))
+                .andExpect(jsonPath("$.page").value(resp.getPage()))
+                .andExpect(jsonPath("$.size").value(resp.getSize()))
                 .andDo(print());
     }
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/SaleControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/SaleControllerTests.java
@@ -1,0 +1,50 @@
+package com.deal4u.fourplease.domain.auction.controller;
+
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genSellerSaleListResponseList;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
+import com.deal4u.fourplease.domain.auction.service.AuctionService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SaleController.class)
+class SaleControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    AuctionService auctionService;
+
+    @Test
+    @DisplayName("GET /api/v1/sales/{sellerId}이 성공하면 id에 해당하는 판매자의 정보와 200을 반환한다")
+    void getSalesShouldReturn200() throws Exception {
+
+        Long sellerId = 1L;
+
+        List<SellerSaleListResponse> resp = genSellerSaleListResponseList();
+
+        when(auctionService.getSalesBySellerId(sellerId)).thenReturn(resp);
+
+        mockMvc.perform(
+                get("/api/v1/sales/{sellerId}", sellerId)
+        ).andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value(resp.get(0).name()))
+                .andExpect(jsonPath("$[1].name").value(resp.get(1).name()))
+                .andExpect(jsonPath("$[2].name").value(resp.get(2).name()))
+                .andDo(print());
+    }
+
+
+
+}

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/SaleControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/SaleControllerTests.java
@@ -34,7 +34,7 @@ class SaleControllerTests {
 
         List<SellerSaleListResponse> resp = genSellerSaleListResponseList();
 
-        when(auctionService.getSalesBySellerId(sellerId)).thenReturn(resp);
+        when(auctionService.findSalesBySellerId(sellerId)).thenReturn(resp);
 
         mockMvc.perform(
                 get("/api/v1/sales/{sellerId}", sellerId)

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -51,7 +51,7 @@ class AuctionServiceTests {
 
     @Test
     @DisplayName("경매를 등록할 수 있다")
-    void save_should_save_auction() throws Exception {
+    void saveShouldSaveAuction() throws Exception {
 
         Member member = genMember();
         AuctionCreateRequest req = genAuctionCreateRequest();
@@ -81,7 +81,7 @@ class AuctionServiceTests {
 
     @Test
     @DisplayName("auctionId로 특정 경매를 조회 후 AuctionDetailResponse를 반환한다")
-    void getByAuctionId_should_return_AuctionDetailResponse() throws Exception {
+    void getByAuctionIdShouldReturnAuctionDetailResponse() throws Exception {
 
         Long auctionId = 1L;
 
@@ -119,7 +119,7 @@ class AuctionServiceTests {
 
     @Test
     @DisplayName("존재하지 않는 auctionId로 조회를 시도하면 404 예외가 발생한다")
-    void throws_when_try_to_get_if_auction_not_exist() throws Exception {
+    void throwsWhenTryToGetIfAuctionNotExist() throws Exception {
 
         Long auctionId = 1L;
         List<Long> bidList = List.of(200_0000L, 150_0000L, 100_0000L);
@@ -139,7 +139,7 @@ class AuctionServiceTests {
 
     @Test
     @DisplayName("auctionId로 경매를 삭제한다")
-    void deleteByAuctionId_should_soft_delete_auction_by_auction_id() throws Exception {
+    void deleteByAuctionIdShouldSoftDeleteAuctionByAuctionId() throws Exception {
 
         Long auctionId = 1L;
 
@@ -156,7 +156,7 @@ class AuctionServiceTests {
 
     @Test
     @DisplayName("존재하지 않는 auctionId로 삭제를 시도하면 404 예외가 발생한다")
-    void throws_when_try_to_delete_if_auction_not_exist() throws Exception {
+    void throwsWhenTryToDeleteIfAuctionNotExist() throws Exception {
 
         Long auctionId = 1L;
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -1,6 +1,7 @@
 package com.deal4u.fourplease.domain.auction.service;
 
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionCreateRequest;
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionList;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genMember;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genProduct;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
+import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductImageListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
@@ -56,7 +58,6 @@ class AuctionServiceTests {
         Member member = genMember();
         AuctionCreateRequest req = genAuctionCreateRequest();
 
-
         ProductCreateDto productDto = req.toProductCreateDto(member);
         Product product = genProduct();
 
@@ -74,8 +75,8 @@ class AuctionServiceTests {
         assertThat(auction.getStartingPrice()).isEqualTo(req.startingPrice());
         assertThat(auction.getInstantBidPrice()).isEqualTo(req.buyNowPrice());
         assertThat(auction.getDuration().getStartTime()).isEqualTo(req.startDate());
-        assertThat(auction.getDuration().getEndTime())
-                .isEqualTo(req.startDate().plusDays(bidPeriod));
+        assertThat(auction.getDuration().getEndTime()).isEqualTo(
+                req.startDate().plusDays(bidPeriod));
         assertThat(auction.getStatus()).isEqualTo(AuctionStatus.OPEN);
     }
 
@@ -85,18 +86,14 @@ class AuctionServiceTests {
 
         Long auctionId = 1L;
 
-        List<BigDecimal> bidList = List.of(
-                BigDecimal.valueOf(200_0000L),
-                BigDecimal.valueOf(150_0000L),
-                BigDecimal.valueOf(100_0000L)
-        );
+        List<BigDecimal> bidList = List.of(BigDecimal.valueOf(2000000L),
+                BigDecimal.valueOf(1500000L), BigDecimal.valueOf(1000000L));
         Product product = genProduct();
         Auction auction = genAuctionCreateRequest().toEntity(product);
 
         ProductImageListResponse productImageListResp = mock(ProductImageListResponse.class);
-        List<String> productImageUrls = List.of(
-                "http://example.com/image1.jpg", "http://example.com/image2.jpg"
-        );
+        List<String> productImageUrls = List.of("http://example.com/image1.jpg",
+                "http://example.com/image2.jpg");
 
         when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(auctionId)).thenReturn(bidList);
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.of(auction));
@@ -125,21 +122,15 @@ class AuctionServiceTests {
     void throwsWhenTryToGetIfAuctionNotExist() throws Exception {
 
         Long auctionId = 1L;
-        List<BigDecimal> bidList = List.of(
-                BigDecimal.valueOf(200_0000L),
-                BigDecimal.valueOf(150_0000L),
-                BigDecimal.valueOf(100_0000L)
-        );
+        List<BigDecimal> bidList = List.of(BigDecimal.valueOf(2000000L),
+                BigDecimal.valueOf(1500000L), BigDecimal.valueOf(1000000L));
 
         when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(auctionId)).thenReturn(bidList);
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(
-                () -> {
-                    auctionService.getByAuctionId(auctionId);
-                }
-        ).isInstanceOf(GlobalException.class)
-                .hasMessage("해당 경매를 찾을 수 없습니다.");
+        assertThatThrownBy(() -> {
+            auctionService.getByAuctionId(auctionId);
+        }).isInstanceOf(GlobalException.class).hasMessage("해당 경매를 찾을 수 없습니다.");
 
     }
 
@@ -168,13 +159,42 @@ class AuctionServiceTests {
 
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(
-                () -> {
-                    auctionService.deleteByAuctionId(auctionId);
-                }
-        ).isInstanceOf(GlobalException.class)
-                .hasMessage("해당 경매를 찾을 수 없습니다.");
+        assertThatThrownBy(() -> {
+            auctionService.deleteByAuctionId(auctionId);
+        }).isInstanceOf(GlobalException.class).hasMessage("해당 경매를 찾을 수 없습니다.");
 
+    }
+
+    @Test
+    @DisplayName("전체 경매 목록을 조회한다")
+    void findAllShouldReturnAuctionList() throws Exception {
+
+        List<Auction> mockAuctions = genAuctionList();
+        when(auctionRepository.findAll()).thenReturn(mockAuctions);
+
+        when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(1L)).thenReturn(
+                List.of(new BigDecimal("200000"), new BigDecimal("150000")));
+        when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(2L)).thenReturn(
+                List.of(new BigDecimal("10000000")));
+        when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(3L)).thenReturn(
+                List.of());  // 빈 리스트
+
+
+        List<AuctionListResponse> resp = auctionService.findAll();
+
+        assertThat(resp).hasSize(3);
+
+        // 1번 경매: maxPrice 200,000, bidCount 2
+        assertThat(resp.get(0).maxPrice()).isEqualByComparingTo("200000");
+        assertThat(resp.get(0).bidCount()).isEqualTo(2);
+
+        // 2번 경매: maxPrice 10,000,000, bidCount 1
+        assertThat(resp.get(1).maxPrice()).isEqualByComparingTo("10000000");
+        assertThat(resp.get(1).bidCount()).isEqualTo(1);
+
+        // 3번 경매: 입찰없음 -> maxPrice 0, bidCount 0
+        assertThat(resp.get(2).maxPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(resp.get(2).bidCount()).isEqualTo(0);
     }
 
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -85,7 +85,11 @@ class AuctionServiceTests {
 
         Long auctionId = 1L;
 
-        List<Long> bidList = List.of(200_0000L, 150_0000L, 100_0000L);
+        List<BigDecimal> bidList = List.of(
+                BigDecimal.valueOf(200_0000L),
+                BigDecimal.valueOf(150_0000L),
+                BigDecimal.valueOf(100_0000L)
+        );
         Product product = genProduct();
         Auction auction = genAuctionCreateRequest().toEntity(product);
 
@@ -94,7 +98,6 @@ class AuctionServiceTests {
                 "http://example.com/image1.jpg", "http://example.com/image2.jpg"
         );
 
-        // TODO: Long -> BigDecimal로 변경 예정
         when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(auctionId)).thenReturn(bidList);
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.of(auction));
 
@@ -103,7 +106,7 @@ class AuctionServiceTests {
 
         AuctionDetailResponse actualResp = auctionService.getByAuctionId(auctionId);
 
-        assertThat(actualResp.highestBidPrice()).isEqualTo(BigDecimal.valueOf(bidList.getFirst()));
+        assertThat(actualResp.highestBidPrice()).isEqualTo(bidList.getFirst());
         assertThat(actualResp.instantBidPrice()).isEqualTo(auction.getInstantBidPrice());
         assertThat(actualResp.bidCount()).isEqualTo(bidList.size());
         assertThat(actualResp.productName()).isEqualTo(product.getName());
@@ -122,9 +125,12 @@ class AuctionServiceTests {
     void throwsWhenTryToGetIfAuctionNotExist() throws Exception {
 
         Long auctionId = 1L;
-        List<Long> bidList = List.of(200_0000L, 150_0000L, 100_0000L);
+        List<BigDecimal> bidList = List.of(
+                BigDecimal.valueOf(200_0000L),
+                BigDecimal.valueOf(150_0000L),
+                BigDecimal.valueOf(100_0000L)
+        );
 
-        // TODO: Long -> BigDecimal로 변경 예정
         when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(auctionId)).thenReturn(bidList);
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.empty());
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -9,7 +9,6 @@ import static com.deal4u.fourplease.domain.auction.util.TestUtils.genProductList
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -31,7 +30,6 @@ import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.GlobalException;
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -179,32 +177,59 @@ class AuctionServiceTests {
     @Test
     @DisplayName("전체 경매 목록을 조회한다")
     void findAllShouldReturnAuctionList() throws Exception {
+
+        Pageable pageable = PageRequest.of(0, 20);
+
         List<Auction> auctionList = genAuctionList();
-        when(auctionRepository.findAll()).thenReturn(auctionList);
 
-        when(auctionSupportService.getAuctionListResponses(anyList()))
-                .thenReturn(genAuctionListResponseList());
-        List<AuctionListResponse> resp = auctionService.findAll();
+        // PageImpl로 Page 객체 모킹
+        Page<Auction> auctionPage = new PageImpl<>(auctionList, pageable, auctionList.size());
 
-        assertThat(resp).hasSize(3);
-        assertThat(resp.get(0).name()).isEqualTo("목도리");
-        assertThat(resp.get(0).maxPrice()).isEqualTo(new BigDecimal("200000"));
-        assertThat(resp.get(1).name()).isEqualTo("축구공");
-        assertThat(resp.get(1).maxPrice()).isEqualTo(new BigDecimal("10000000"));
-        assertThat(resp.get(2).maxPrice()).isEqualTo(new BigDecimal("2000000"));
-        assertThat(resp.get(2).name()).isEqualTo("칫솔");
+        List<AuctionListResponse> auctionListResponseList = genAuctionListResponseList();
+        Page<AuctionListResponse> auctionListResponsePage = new PageImpl<>(
+                auctionListResponseList,
+                pageable,
+                auctionListResponseList.size()
+        );
+
+        when(auctionRepository.findAll(pageable)).thenReturn(auctionPage);
+        when(auctionSupportService.getAuctionListResponses(auctionPage))
+                .thenReturn(auctionListResponsePage);
+
+        PageResponse<AuctionListResponse> resp = auctionService.findAll(pageable);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.getContent()).hasSize(3);
+        assertThat(resp.getContent().get(0).name()).isEqualTo("목도리");
+        assertThat(resp.getContent().get(0).maxPrice()).isEqualTo(new BigDecimal("200000"));
+        assertThat(resp.getContent().get(1).name()).isEqualTo("축구공");
+        assertThat(resp.getContent().get(1).maxPrice()).isEqualTo(new BigDecimal("10000000"));
+        assertThat(resp.getContent().get(2).maxPrice()).isEqualTo(new BigDecimal("2000000"));
+        assertThat(resp.getContent().get(2).name()).isEqualTo("칫솔");
+
+        assertThat(resp.getTotalElements()).isEqualTo(3);
+        assertThat(resp.getTotalPages()).isEqualTo(1);
+        assertThat(resp.getPage()).isEqualTo(0);
+        assertThat(resp.getSize()).isEqualTo(20);
     }
 
     @Test
     @DisplayName("경매 목록이 없을 경우 빈 리스트를 반환한다")
     void findAllShouldReturnEmptyListWhenNoAuctionsExist() {
 
-        when(auctionRepository.findAll()).thenReturn(Collections.emptyList());
+        Pageable pageable = PageRequest.of(0, 20);
 
-        List<AuctionListResponse> resp = auctionService.findAll();
+        when(auctionRepository.findAll(pageable)).thenReturn(Page.empty(pageable));
+        when(auctionSupportService.getAuctionListResponses(Page.empty(pageable)))
+                .thenReturn(Page.empty(pageable));
+
+        PageResponse<AuctionListResponse> resp = auctionService.findAll(pageable);
 
         assertThat(resp).isNotNull();
-        assertThat(resp).isEmpty();
+        assertThat(resp.getTotalElements()).isEqualTo(0);
+        assertThat(resp.getTotalPages()).isEqualTo(0);
+        assertThat(resp.getPage()).isEqualTo(0);
+        assertThat(resp.getSize()).isEqualTo(20);
     }
 
     @Test
@@ -242,7 +267,8 @@ class AuctionServiceTests {
         when(auctionSupportService.getSaleAuctionStatus(any(Auction.class)))
                 .thenReturn(SaleAuctionStatus.OPEN);
 
-        PageResponse<SellerSaleListResponse> resp = auctionService.findSalesBySellerId(sellerId, pageable);
+        PageResponse<SellerSaleListResponse> resp =
+                auctionService.findSalesBySellerId(sellerId, pageable);
 
         assertThat(resp).isNotNull();
         assertThat(resp.getContent()).hasSize(3);

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -19,6 +19,7 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
+import com.deal4u.fourplease.domain.auction.dto.PageResponse;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductImageListResponse;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
@@ -40,6 +41,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionServiceTests {
@@ -207,13 +212,18 @@ class AuctionServiceTests {
     void findSalesBySellerIdShouldReturnSellerSaleList() throws Exception {
 
         Long sellerId = 1L;
+        Pageable pageable = PageRequest.of(0, 20);
 
         List<Product> productList = genProductList();
         List<Long> productIdList = List.of(1L, 2L, 3L);
         List<Auction> auctionList = genAuctionList();
 
+        // PageImpl로 Page 객체 모킹
+        Page<Auction> auctionPage = new PageImpl<>(auctionList, pageable, auctionList.size());
+
         when(productService.getProductListBySellerId(sellerId)).thenReturn(productList);
-        when(auctionRepository.findAllByProductId(productIdList)).thenReturn(auctionList);
+        when(auctionRepository.findAllByProductIdIn(productIdList, pageable))
+                .thenReturn(auctionPage);
 
         when(auctionSupportService.getBidSummaryDto(anyLong()))
                 // id 별로 다른 값 반환
@@ -232,16 +242,24 @@ class AuctionServiceTests {
         when(auctionSupportService.getSaleAuctionStatus(any(Auction.class)))
                 .thenReturn(SaleAuctionStatus.OPEN);
 
-        List<SellerSaleListResponse> resp = auctionService.findSalesBySellerId(sellerId);
+        PageResponse<SellerSaleListResponse> resp = auctionService.findSalesBySellerId(sellerId, pageable);
 
         assertThat(resp).isNotNull();
-        assertThat(resp).hasSize(3);
-        assertThat(resp.get(0).name()).isEqualTo(productList.get(0).getName());
-        assertThat(resp.get(0).thumbnailUrl()).isEqualTo(productList.get(0).getThumbnailUrl());
-        assertThat(resp.get(1).name()).isEqualTo(productList.get(1).getName());
-        assertThat(resp.get(1).thumbnailUrl()).isEqualTo(productList.get(1).getThumbnailUrl());
-        assertThat(resp.get(2).name()).isEqualTo(productList.get(2).getName());
-        assertThat(resp.get(2).thumbnailUrl()).isEqualTo(productList.get(2).getThumbnailUrl());
+        assertThat(resp.getContent()).hasSize(3);
+        assertThat(resp.getContent().get(0).name()).isEqualTo(productList.get(0).getName());
+        assertThat(resp.getContent().get(0).thumbnailUrl())
+                .isEqualTo(productList.get(0).getThumbnailUrl());
+        assertThat(resp.getContent().get(1).name()).isEqualTo(productList.get(1).getName());
+        assertThat(resp.getContent().get(1).thumbnailUrl())
+                .isEqualTo(productList.get(1).getThumbnailUrl());
+        assertThat(resp.getContent().get(2).name()).isEqualTo(productList.get(2).getName());
+        assertThat(resp.getContent().get(2).thumbnailUrl())
+                .isEqualTo(productList.get(2).getThumbnailUrl());
+
+        assertThat(resp.getTotalElements()).isEqualTo(3);
+        assertThat(resp.getTotalPages()).isEqualTo(1);
+        assertThat(resp.getPage()).isEqualTo(0);
+        assertThat(resp.getSize()).isEqualTo(20);
     }
 
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -23,6 +23,7 @@ import com.deal4u.fourplease.domain.bid.repository.BidRepository;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.GlobalException;
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -177,7 +178,7 @@ class AuctionServiceTests {
         when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(2L)).thenReturn(
                 List.of(new BigDecimal("10000000")));
         when(bidRepository.findPricesByAuctionIdOrderByPriceDesc(3L)).thenReturn(
-                List.of());  // 빈 리스트
+                List.of());
 
 
         List<AuctionListResponse> resp = auctionService.findAll();
@@ -185,16 +186,28 @@ class AuctionServiceTests {
         assertThat(resp).hasSize(3);
 
         // 1번 경매: maxPrice 200,000, bidCount 2
-        assertThat(resp.get(0).maxPrice()).isEqualByComparingTo("200000");
+        assertThat(resp.get(0).maxPrice()).isEqualTo(new BigDecimal("200000"));
         assertThat(resp.get(0).bidCount()).isEqualTo(2);
 
         // 2번 경매: maxPrice 10,000,000, bidCount 1
-        assertThat(resp.get(1).maxPrice()).isEqualByComparingTo("10000000");
+        assertThat(resp.get(1).maxPrice()).isEqualTo(new BigDecimal("10000000"));
         assertThat(resp.get(1).bidCount()).isEqualTo(1);
 
         // 3번 경매: 입찰없음 -> maxPrice 0, bidCount 0
-        assertThat(resp.get(2).maxPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(resp.get(2).maxPrice()).isEqualTo(BigDecimal.ZERO);
         assertThat(resp.get(2).bidCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("경매 목록이 없을 경우 빈 리스트를 반환한다")
+    void findAllShouldReturnEmptyListWhenNoAuctionsExist() {
+
+        when(auctionRepository.findAll()).thenReturn(Collections.emptyList());
+
+        List<AuctionListResponse> resp = auctionService.findAll();
+
+        assertThat(resp).isNotNull();
+        assertThat(resp).isEmpty();
     }
 
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/ProductImageServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/ProductImageServiceTests.java
@@ -35,7 +35,7 @@ class ProductImageServiceTests {
 
     @Test
     @DisplayName("상품 이미지 url 리스트를 받아 등록할 있다")
-    void product_image_can_be_saved() throws Exception {
+    void productImageCanBeSaved() throws Exception {
 
         Product product = mock(Product.class);
         List<String> imageUrls = List.of(
@@ -60,7 +60,7 @@ class ProductImageServiceTests {
 
     @Test
     @DisplayName("product를 인자로 받아 productId로 이미지 리스트를 찾아 반환한다")
-    void return_product_image_list_by_product_id() throws Exception {
+    void returnProductImageListByProductId() throws Exception {
 
         Product product = genProduct();
         List<ProductImage> productImageList = genProductImageList(product);
@@ -83,7 +83,7 @@ class ProductImageServiceTests {
 
     @Test
     @DisplayName("productId로 조회한 이미지 리스트가 빈 값이면 400 예외가 발생한다")
-    void throw_if_image_list_empty() throws Exception {
+    void throwIfImageListEmpty() throws Exception {
 
         Product product = genProduct();
         List<ProductImage> productImageList = List.of();
@@ -102,7 +102,7 @@ class ProductImageServiceTests {
 
     @Test
     @DisplayName("product를 인자로 받아 productImage 리스트를 삭제한다")
-    void productImage_list_can_be_deleted_by_product() throws Exception {
+    void productImageListCanBeDeletedByProduct() throws Exception {
 
         Product product = genProduct();
         List<ProductImage> productImageList = genProductImageList(product);
@@ -117,7 +117,7 @@ class ProductImageServiceTests {
 
     @Test
     @DisplayName("product에 해당하는 이미지 url 리스트가 없을 경우 400 예외가 발생한다")
-    void throws_if_image_urls_not_exist() throws Exception {
+    void throwsIfImageUrlsNotExist() throws Exception {
 
         Product product = genProduct();
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/ProductServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/ProductServiceTests.java
@@ -43,7 +43,7 @@ class ProductServiceTests {
 
     @Test
     @DisplayName("상품을 등록하고 등록된 상품을 반환한다")
-    void product_can_be_saved_and_returned() throws Exception {
+    void productCanBeSavedAndReturned() throws Exception {
 
         ProductCreateDto req = genProductCreateDto();
         Member seller = genMember();
@@ -67,7 +67,7 @@ class ProductServiceTests {
 
     @Test
     @DisplayName("존재하지 않는 id로 카테고리 조회 시 예외가 발생한다")
-    void throws_if_category_not_found() throws Exception {
+    void throwsIfCategoryNotFound() throws Exception {
 
         ProductCreateDto wrongRequest = genProductCreateDto();
 
@@ -83,7 +83,7 @@ class ProductServiceTests {
 
     @Test
     @DisplayName("product를 인자로 받아 soft delete를 실행한다")
-    void deleteProduct_should_soft_delete_product_by_product() throws Exception {
+    void deleteProductShouldSoftDeleteProductByProduct() throws Exception {
 
         Product product = genProduct();
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -2,6 +2,8 @@ package com.deal4u.fourplease.domain.auction.util;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
+import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
+import com.deal4u.fourplease.domain.auction.dto.CategoryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.entity.Address;
 import com.deal4u.fourplease.domain.auction.entity.BidPeriod;
@@ -97,5 +99,43 @@ public class TestUtils {
                 new ProductImage(1L, product, "http://example.com/image1.jpg"),
                 new ProductImage(2L, product, "http://example.com/image2.jpg")
         );
+    }
+
+    public static List<AuctionListResponse> genAuctionListResponseList() {
+         return List.of(
+                 new AuctionListResponse(
+                         1L,
+                         "http://example.com/thumbnail1.jpg",
+                         new CategoryDto(0L, "패션"),
+                         "목도리",
+                         BigDecimal.valueOf(200_000),
+                         BigDecimal.valueOf(250_000),
+                         5,
+                         LocalDateTime.now().plusDays(3),
+                         false
+                 ),
+                 new AuctionListResponse(
+                         2L,
+                         "http://example.com/thumbnail2.jpg",
+                         new CategoryDto(2L, "스포츠"),
+                         "축구공",
+                         BigDecimal.valueOf(10_000_000),
+                         null,
+                         150,
+                         LocalDateTime.now().plusDays(7),
+                         true
+                 ),
+                 new AuctionListResponse(
+                         3L,
+                         "http://example.com/thumbnail3.jpg",
+                         new CategoryDto(4L, "생활용품"),
+                         "칫솔",
+                         BigDecimal.valueOf(200_0000),
+                         null,
+                         20,
+                         LocalDateTime.now(),
+                         false
+                 )
+         );
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class TestUtils {
 
-     public static ProductCreateDto genProductCreateDto() {
+    public static ProductCreateDto genProductCreateDto() {
         return new ProductCreateDto(
                 genMember(),
                 "칫솔",
@@ -107,41 +107,41 @@ public class TestUtils {
     }
 
     public static List<AuctionListResponse> genAuctionListResponseList() {
-         return List.of(
-                 new AuctionListResponse(
-                         1L,
-                         "http://example.com/thumbnail1.jpg",
-                         new CategoryDto(0L, "패션"),
-                         "목도리",
-                         BigDecimal.valueOf(200000),
-                         BigDecimal.valueOf(250000),
-                         5,
-                         LocalDateTime.now().plusDays(3),
-                         false
-                 ),
-                 new AuctionListResponse(
-                         2L,
-                         "http://example.com/thumbnail2.jpg",
-                         new CategoryDto(2L, "스포츠"),
-                         "축구공",
-                         BigDecimal.valueOf(10000000),
-                         null,
-                         150,
-                         LocalDateTime.now().plusDays(7),
-                         true
-                 ),
-                 new AuctionListResponse(
-                         3L,
-                         "http://example.com/thumbnail3.jpg",
-                         new CategoryDto(4L, "생활용품"),
-                         "칫솔",
-                         BigDecimal.valueOf(2000000),
-                         null,
-                         20,
-                         LocalDateTime.now(),
-                         false
-                 )
-         );
+        return List.of(
+                new AuctionListResponse(
+                        1L,
+                        "http://example.com/thumbnail1.jpg",
+                        new CategoryDto(0L, "패션"),
+                        "목도리",
+                        BigDecimal.valueOf(200000),
+                        BigDecimal.valueOf(250000),
+                        5,
+                        LocalDateTime.now().plusDays(3),
+                        false
+                ),
+                new AuctionListResponse(
+                        2L,
+                        "http://example.com/thumbnail2.jpg",
+                        new CategoryDto(2L, "스포츠"),
+                        "축구공",
+                        BigDecimal.valueOf(10000000),
+                        null,
+                        150,
+                        LocalDateTime.now().plusDays(7),
+                        true
+                ),
+                new AuctionListResponse(
+                        3L,
+                        "http://example.com/thumbnail3.jpg",
+                        new CategoryDto(4L, "생활용품"),
+                        "칫솔",
+                        BigDecimal.valueOf(2000000),
+                        null,
+                        20,
+                        LocalDateTime.now(),
+                        false
+                )
+        );
     }
 
     public static List<Auction> genAuctionList() {
@@ -167,8 +167,7 @@ public class TestUtils {
                         .instantBidPrice(BigDecimal.valueOf(250000))
                         .duration(new AuctionDuration(LocalDateTime.now(),
                                 LocalDateTime.now().plusDays(3)))
-                        .build()
-                ,
+                        .build(),
                 Auction.builder()
                         .auctionId(2L)
                         .product(

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -5,6 +5,7 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.CategoryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
+import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Address;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionDuration;
@@ -213,6 +214,41 @@ public class TestUtils {
                                 LocalDateTime.now().plusDays(1)))
                         .build()
 
+        );
+    }
+
+    public static List<SellerSaleListResponse> genSellerSaleListResponseList() {
+        return List.of(
+                new SellerSaleListResponse(
+                        1L,
+                        "http://example.com/thumbnail1.jpg",
+                        "목도리",
+                        BigDecimal.valueOf(2000000),
+                        BigDecimal.valueOf(1000000),
+                        "목에 둘러도 따뜻하지 않은 목도리",
+                        5,
+                        "OPEN"
+                ),
+                new SellerSaleListResponse(
+                        2L,
+                        "http://example.com/thumbnail2.jpg",
+                        "축구공",
+                        BigDecimal.valueOf(10000000),
+                        BigDecimal.valueOf(5000000),
+                        "손흥민의 싸인이 있는 축구공",
+                        20,
+                        "OPEN"
+                ),
+                new SellerSaleListResponse(
+                        3L,
+                        "http://example.com/thumbnail3.jpg",
+                        "칫솔",
+                        BigDecimal.valueOf(2000000),
+                        BigDecimal.valueOf(100000),
+                        "한 번도 사용하지 않은 새 칫솔 입니다. 치약은 없습니다.",
+                        20,
+                        "CLOSE"
+                )
         );
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -250,4 +250,52 @@ public class TestUtils {
                 )
         );
     }
+
+    public static List<Product> genProductList() {
+        return List.of(
+                Product.builder()
+                        .productId(1L)
+                        .name("목도리")
+                        .description("목에 둘러도 따뜻하지 않은 목도리")
+                        .thumbnailUrl("http://example.com/thumbnail1.jpg")
+                        .address(new Address(
+                                "서울시 서초구",
+                                "101동 102호",
+                                "999999"
+                        ))
+                        .seller(Seller.create(genMember()))
+                        .category(new Category(0L, "패션"))
+                        .phone("010-9999-9999")
+                        .build(),
+                Product.builder()
+                        .productId(2L)
+                        .name("축구공")
+                        .description("손흥민의 싸인이 있는 축구공")
+                        .thumbnailUrl("http://example.com/thumbnail2.jpg")
+                        .address(new Address(
+                                "서울시 광진구",
+                                "101동 102호",
+                                "333333"
+                        ))
+                        .seller(Seller.create(genMember()))
+                        .category(new Category(2L, "스포츠"))
+                        .phone("010-3333-3333")
+                        .build(),
+                Product.builder()
+                        .productId(3L)
+                        .name("칫솔")
+                        .description("한 번도 사용하지 않은 새 칫솔 입니다. 치약은 없습니다.")
+                        .thumbnailUrl("http://example.com/thumbnail3.jpg")
+                        .address(new Address(
+                                "서울시 강남구",
+                                "101동 102호",
+                                "000000"
+                        ))
+                        .seller(Seller.create(genMember()))
+                        .category(new Category(4L, "생활용품"))
+                        .phone("010-0000-0000")
+                        .build()
+        );
+    }
+
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -4,6 +4,7 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.CategoryDto;
+import com.deal4u.fourplease.domain.auction.dto.PageResponse;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Address;
@@ -216,8 +217,8 @@ public class TestUtils {
         );
     }
 
-    public static List<SellerSaleListResponse> genSellerSaleListResponseList() {
-        return List.of(
+    public static PageResponse<SellerSaleListResponse> genSellerSaleListResponsePageResponse() {
+        List<SellerSaleListResponse> content = List.of(
                 new SellerSaleListResponse(
                         1L,
                         "http://example.com/thumbnail1.jpg",
@@ -249,6 +250,14 @@ public class TestUtils {
                         "CLOSE"
                 )
         );
+
+        return PageResponse.<SellerSaleListResponse>builder()
+                .content(content)
+                .totalElements(3L)
+                .totalPages(1)
+                .page(0)
+                .size(10)
+                .build();
     }
 
     public static List<Product> genProductList() {

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -6,10 +6,13 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.CategoryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.entity.Address;
+import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionDuration;
 import com.deal4u.fourplease.domain.auction.entity.BidPeriod;
 import com.deal4u.fourplease.domain.auction.entity.Category;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.entity.ProductImage;
+import com.deal4u.fourplease.domain.auction.entity.Seller;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.member.entity.Role;
 import com.deal4u.fourplease.domain.member.entity.Status;
@@ -55,6 +58,7 @@ public class TestUtils {
                         "101동 102호",
                         "000000"
                 ))
+                .seller(Seller.create(genMember()))
                 .category(new Category(4L, "생활용품"))
                 .phone("010-0000-0000")
                 .build();
@@ -73,17 +77,17 @@ public class TestUtils {
                 "010-0000-0000",
                 LocalDateTime.now(),
                 BidPeriod.THREE,
-                BigDecimal.valueOf(100_000),
+                BigDecimal.valueOf(100000),
                 null
         );
     }
 
     public static AuctionDetailResponse genAuctionDetailResponse() {
         return new AuctionDetailResponse(
-                BigDecimal.valueOf(200_0000),
+                BigDecimal.valueOf(2000000),
                 null,
                 20,
-                BigDecimal.valueOf(100_0000),
+                BigDecimal.valueOf(1000000),
                 "칫솔",
                 4L,
                 "생활용품",
@@ -108,8 +112,8 @@ public class TestUtils {
                          "http://example.com/thumbnail1.jpg",
                          new CategoryDto(0L, "패션"),
                          "목도리",
-                         BigDecimal.valueOf(200_000),
-                         BigDecimal.valueOf(250_000),
+                         BigDecimal.valueOf(200000),
+                         BigDecimal.valueOf(250000),
                          5,
                          LocalDateTime.now().plusDays(3),
                          false
@@ -119,7 +123,7 @@ public class TestUtils {
                          "http://example.com/thumbnail2.jpg",
                          new CategoryDto(2L, "스포츠"),
                          "축구공",
-                         BigDecimal.valueOf(10_000_000),
+                         BigDecimal.valueOf(10000000),
                          null,
                          150,
                          LocalDateTime.now().plusDays(7),
@@ -130,12 +134,85 @@ public class TestUtils {
                          "http://example.com/thumbnail3.jpg",
                          new CategoryDto(4L, "생활용품"),
                          "칫솔",
-                         BigDecimal.valueOf(200_0000),
+                         BigDecimal.valueOf(2000000),
                          null,
                          20,
                          LocalDateTime.now(),
                          false
                  )
          );
+    }
+
+    public static List<Auction> genAuctionList() {
+        return List.of(
+                Auction.builder()
+                        .auctionId(1L)
+                        .product(
+                                Product.builder()
+                                        .name("목도리")
+                                        .description("목에 둘러도 따뜻하지 않은 목도리")
+                                        .thumbnailUrl("http://example.com/thumbnail1.jpg")
+                                        .address(new Address(
+                                                "서울시 서초구",
+                                                "101동 102호",
+                                                "999999"
+                                        ))
+                                        .seller(Seller.create(genMember()))
+                                        .category(new Category(0L, "패션"))
+                                        .phone("010-9999-9999")
+                                        .build()
+                        )
+                        .startingPrice(BigDecimal.valueOf(100000))
+                        .instantBidPrice(BigDecimal.valueOf(250000))
+                        .duration(new AuctionDuration(LocalDateTime.now(),
+                                LocalDateTime.now().plusDays(3)))
+                        .build()
+                ,
+                Auction.builder()
+                        .auctionId(2L)
+                        .product(
+                                Product.builder()
+                                        .name("축구공")
+                                        .description("손흥민의 싸인이 있는 축구공")
+                                        .thumbnailUrl("http://example.com/thumbnail2.jpg")
+                                        .address(new Address(
+                                                "서울시 광진구",
+                                                "101동 102호",
+                                                "333333"
+                                        ))
+                                        .seller(Seller.create(genMember()))
+                                        .category(new Category(2L, "스포츠"))
+                                        .phone("010-3333-3333")
+                                        .build()
+                        )
+                        .startingPrice(BigDecimal.valueOf(5000000))
+                        .instantBidPrice(null)
+                        .duration(new AuctionDuration(LocalDateTime.now(),
+                                LocalDateTime.now().plusDays(7)))
+                        .build(),
+                Auction.builder()
+                        .auctionId(3L)
+                        .product(
+                                Product.builder()
+                                        .name("칫솔")
+                                        .description("한 번도 사용하지 않은 새 칫솔 입니다. 치약은 없습니다.")
+                                        .thumbnailUrl("http://example.com/thumbnail3.jpg")
+                                        .address(new Address(
+                                                "서울시 강남구",
+                                                "101동 102호",
+                                                "000000"
+                                        ))
+                                        .seller(Seller.create(genMember()))
+                                        .category(new Category(4L, "생활용품"))
+                                        .phone("010-0000-0000")
+                                        .build()
+                        )
+                        .startingPrice(BigDecimal.valueOf(100000))
+                        .instantBidPrice(null)
+                        .duration(new AuctionDuration(LocalDateTime.now(),
+                                LocalDateTime.now().plusDays(1)))
+                        .build()
+
+        );
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -145,6 +145,17 @@ public class TestUtils {
         );
     }
 
+    public static PageResponse<AuctionListResponse> genAuctionListResponsePageResponse() {
+        return PageResponse.<AuctionListResponse>builder()
+                .content(genAuctionListResponseList())
+                .totalElements(3L)
+                .totalPages(1)
+                .page(0)
+                .size(20)
+                .build();
+
+    }
+
     public static List<Auction> genAuctionList() {
         return List.of(
                 Auction.builder()
@@ -256,7 +267,7 @@ public class TestUtils {
                 .totalElements(3L)
                 .totalPages(1)
                 .page(0)
-                .size(10)
+                .size(20)
                 .build();
     }
 

--- a/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
@@ -135,7 +135,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("즉시 구매(BUY_NOW) 주문이 정상적으로 생성되는 경우")
-        void testCreateOrder_BuyNowSuccessful() {
+        void testCreateOrderBuyNowSuccessful() {
             // Given
             Long auctionId = 1L;
             String orderType = "BUY_NOW";
@@ -155,7 +155,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("즉시 구매(BUY_NOW) 주문에서 가격이 일치하지 않는 경우 예외 발생")
-        void testCreateOrder_BuyNowInvalidPrice() {
+        void testCreateOrderBuyNowInvalidPrice() {
             // Given
             Long auctionId = 1L;
             String orderType = "BUY_NOW";
@@ -180,7 +180,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("낙찰자가 AWARD 타입의 주문을 정상적으로 생성하는 경우")
-        void testCreateOrder_AwardSuccessful() {
+        void testCreateOrderAwardSuccessful() {
             // Given
             String orderType = "AWARD";
 
@@ -210,7 +210,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("AWARD 타입의 주문에서 가격이 일치하지 않는 경우 예외 발생")
-        void testCreateOrder_AwardInvalidPrice() {
+        void testCreateOrderAwardInvalidPrice() {
             // Given
             String orderType = "AWARD";
 
@@ -237,7 +237,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("경매를 찾을 수 없는 경우 예외 발생")
-        void testCreateOrder_AuctionNotFound() {
+        void testCreateOrderAuctionNotFound() {
             // Given
             Long auctionId = 1L;
             String orderType = "BUY_NOW";
@@ -258,7 +258,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("사용자를 찾을 수 없는 경우 예외 발생")
-        void testCreateOrder_UserNotFound() {
+        void testCreateOrderUserNotFound() {
             // Given
             Long auctionId = 1L;
             String orderType = "BUY_NOW";
@@ -277,7 +277,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("AWARD 타입의 주문에서 유효하지 않은 입찰자일 경우 예외 발생")
-        void testCreateOrder_InvalidBidderForAward() {
+        void testCreateOrderInvalidBidderForAward() {
             // Given
             Long auctionId = 1L;
             String orderType = "AWARD";
@@ -300,7 +300,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("유효하지 않은 주문 타입인 경우 예외 발생")
-        void testCreateOrder_InvalidOrderType() {
+        void testCreateOrderInvalidOrderType() {
             // Given
             Long auctionId = 1L;
             String orderType = "INVALID_TYPE";
@@ -316,7 +316,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("BUY_NOW 타입 주문에서 즉시 구매가 정확히 처리되는지 확인")
-        void testCreateOrder_BuyNowTypeValidation() {
+        void testCreateOrderBuyNowTypeValidation() {
             // Given
             Long auctionId = 1L;
             String orderType = "BUY_NOW";
@@ -343,7 +343,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("AWARD 타입 주문에서 낙찰가가 정확히 처리되는지 확인")
-        void testCreateOrder_AwardTypeValidation() {
+        void testCreateOrderAwardTypeValidation() {
             // Given
             Long auctionId = 1L;
             String orderType = "AWARD";
@@ -371,7 +371,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("OrderType enum의 fromString 메서드 - 유효한 타입들 검증")
-        void testOrderType_FromStringValidation() {
+        void testOrderTypeFromStringValidation() {
             // Given & When & Then
             assertThat(OrderType.fromString("BUY_NOW")).isEqualTo(OrderType.BUY_NOW);
             assertThat(OrderType.fromString("AWARD")).isEqualTo(OrderType.AWARD);
@@ -383,7 +383,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("OrderType enum의 fromString 메서드 - 유효하지 않은 문자열 예외 검증")
-        void testOrderType_FromStringInvalidValue() {
+        void testOrderTypeFromStringInvalidValue() {
             // Given & When & Then
             assertThatThrownBy(() -> OrderType.fromString("INVALID"))
                     .isInstanceOf(IllegalArgumentException.class);
@@ -391,7 +391,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("OrderType enum의 fromString 메서드 - null 값 예외 검증")
-        void testOrderType_FromStringNullValue() {
+        void testOrderTypeFromStringNullValue() {
             // Given & When & Then
             assertThatThrownBy(() -> OrderType.fromString(null))
                     .isInstanceOf(IllegalArgumentException.class);
@@ -403,7 +403,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("주문 조회가 정상적으로 수행되는 경우")
-        void testGetOrder_Successful() {
+        void testGetOrderSuccessful() {
             // Given
             Long orderId = 1L;
 
@@ -440,7 +440,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("존재하지 않는 주문을 조회하는 경우 예외 발생")
-        void testGetOrder_OrderNotFound() {
+        void testGetOrderOrderNotFound() {
             // Given
             Long orderId = 999L;
 
@@ -461,7 +461,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("주문 업데이트가 정상적으로 수행되는 경우")
-        void testUpdateOrder_Successful() {
+        void testUpdateOrderSuccessful() {
             // Given
             Long orderId = 1L;
 
@@ -502,7 +502,7 @@ class OrderServiceTest {
 
         @Test
         @DisplayName("존재하지 않는 주문을 업데이트하려는 경우 예외 발생")
-        void testUpdateOrder_OrderNotFound() {
+        void testUpdateOrderOrderNotFound() {
             // Given
             Long orderId = 999L;
 

--- a/src/test/java/com/deal4u/fourplease/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/payment/service/PaymentServiceTest.java
@@ -97,9 +97,7 @@ class PaymentServiceTest {
 
     @Test
     @DisplayName("결제 승인 성공 - 정상적인 결제 처리")
-    void paymentConfirm_Success_Improved() {
-
-        String LOCK_PREFIX = "auction-lock:";
+    void paymentConfirmSuccessImproved() {
 
         // given
         when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
@@ -115,6 +113,8 @@ class PaymentServiceTest {
         // when
         paymentService.paymentConfirm(confirmRequest);
 
+        String lockPrefix = "auction-lock:";
+
         // then
         verify(paymentTransactionService).getOrderOrThrow(any(OrderId.class));
         verify(namedLock).lock();
@@ -122,12 +122,12 @@ class PaymentServiceTest {
         verify(paymentTransactionService).savePayment(order, confirmRequest, successResponse,
                 order.getAuction());
         verify(namedLock).unlock();
-        verify(namedLockProvider).getBottleLock(LOCK_PREFIX + order.getAuction().getAuctionId());
+        verify(namedLockProvider).getBottleLock(lockPrefix + order.getAuction().getAuctionId());
     }
 
     @Test
     @DisplayName("결제 승인 실패 - 주문을 찾을 수 없음")
-    void paymentConfirm_OrderNotFound() {
+    void paymentConfirmOrderNotFound() {
         // given
         when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
                 .thenThrow(ErrorCode.ORDER_NOT_FOUND.toException());
@@ -142,13 +142,13 @@ class PaymentServiceTest {
 
     @Test
     @DisplayName("결제 승인 실패 - 토스 API 응답 상태가 실패")
-    void paymentConfirm_PaymentStatusFailed() {
-        String LOCK_PREFIX = "auction-lock:";
+    void paymentConfirmPaymentStatusFailed() {
+        String lockPrefix = "auction-lock:";
 
         // given
         when(paymentTransactionService.getOrderOrThrow(any(OrderId.class)))
                 .thenReturn(order);
-        when(namedLockProvider.getBottleLock(LOCK_PREFIX + order.getAuction().getAuctionId()))
+        when(namedLockProvider.getBottleLock(lockPrefix + order.getAuction().getAuctionId()))
                 .thenReturn(namedLock);
         when(tossApiClient.confirmPayment(confirmRequest))
                 .thenReturn(failedResponse);
@@ -166,7 +166,7 @@ class PaymentServiceTest {
 
     @Test
     @DisplayName("결제 승인 실패 - 결제 금액이 주문 금액과 다름")
-    void paymentConfirm_InvalidAmount() {
+    void paymentConfirmInvalidAmount() {
         // given
         TossPaymentConfirmRequest invalidAmountRequest = new TossPaymentConfirmRequest(
                 "paymentKey123",


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #20 

## 📝 작업 내용
- 상품-경매 전체 조회 및 페이지네이션 적용
- 판매자 판매내역 조회 및 페이지네이션 적용

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- api 명세에 상태 코드 200 밖에 없어서 임의로 404를 추가했습니다.
- validate가 잘 되어있는지 의문이 듭니다.
- 실패 테스트가 부족하다고 생각합니다. 실패 테스트가 필요한 케이스를 조언해주시면 감사하겠습니다.