### PR TITLE
fix(63):  경매 및 위시리스트 삭제 시도 시 멤버 검증 로직 추가 - 정미광

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -80,11 +80,15 @@ public class AuctionController {
 
     @Operation(summary = "경매제거")
     @ApiResponse(responseCode = "204", description = "경매 삭제 성공")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
     @ApiResponse(responseCode = "409", description = "낙찰된 경매는 제거 불가능")
     @DeleteMapping("/{auctionId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteAuction(@PathVariable(name = "auctionId") @Positive Long auctionId) {
-        auctionService.deleteByAuctionId(auctionId);
+    public void deleteAuction(
+            @PathVariable(name = "auctionId") @Positive Long auctionId,
+            @AuthenticationPrincipal Member member
+    ) {
+        auctionService.deleteByAuctionId(auctionId, member);
     }
 
     @Operation(summary = "이미지 업로드")

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionListResponse.java
@@ -25,7 +25,6 @@ public record AuctionListResponse(
     public static AuctionListResponse toAuctionListResponse(
             Auction auction,
             BidSummaryDto bidSummaryDto,
-            // TODO: wishlist 개발 후 수정 필요
             boolean isWishlist
     ) {
         Product product = auction.getProduct();

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/ProductImageListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/ProductImageListResponse.java
@@ -4,12 +4,12 @@ import com.deal4u.fourplease.domain.auction.entity.ProductImage;
 import java.util.ArrayList;
 import java.util.List;
 
-public record ProductImageListResponse(List<ProductImage> productImageList) {
+public record ProductImageListResponse(List<ProductImage> productImages) {
 
-    public List<String> toProductImageUrlList() {
+    public List<String> toProductImageUrls() {
         List<String> imageUrls = new ArrayList<>();
 
-        for (ProductImage image : productImageList) {
+        for (ProductImage image : productImages) {
             imageUrls.add(image.getUrl());
         }
 

--- a/src/main/java/com/deal4u/fourplease/domain/auction/entity/Seller.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/entity/Seller.java
@@ -16,8 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Seller {
 
-    // TODO: 병합 후 cascade = CascadeType.PERSIST 삭제 필요
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
     public static Seller create(Member member) {

--- a/src/main/java/com/deal4u/fourplease/domain/auction/reader/AuctionReader.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/reader/AuctionReader.java
@@ -1,0 +1,7 @@
+package com.deal4u.fourplease.domain.auction.reader;
+
+import com.deal4u.fourplease.domain.auction.entity.Auction;
+
+public interface AuctionReader {
+    Auction getAuctionByAuctionId(Long auctionId);
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -37,10 +37,10 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "FROM Auction a "
             + "JOIN FETCH a.product p "
             + "WHERE a.deleted = false "
-            + "AND p.productId in :productIdList "
+            + "AND p.productId in :productIds "
             + "ORDER BY a.createdAt DESC")
     Page<Auction> findAllByProductIdIn(
-            @Param("productIdList") List<Long> productIdList,
+            @Param("productIds") List<Long> productIds,
             Pageable pageable
     );
 

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionReaderImpl.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionReaderImpl.java
@@ -1,0 +1,23 @@
+package com.deal4u.fourplease.domain.auction.service;
+
+import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.reader.AuctionReader;
+import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
+import com.deal4u.fourplease.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionReaderImpl implements AuctionReader {
+
+    private final AuctionRepository auctionRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Auction getAuctionByAuctionId(Long auctionId) {
+        return auctionRepository.findByIdWithProduct(auctionId)
+                .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
+    }
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -58,11 +58,11 @@ public class AuctionService {
         Auction auction = auctionRepository.findByIdWithProduct(auctionId)
                 .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
 
-        List<String> productImageUrlList = getProductImageUrlList(auction.getProduct());
+        List<String> productImageUrls = getProductImageUrls(auction.getProduct());
 
         return AuctionDetailResponse.toAuctionDetailResponse(
                 auction,
-                productImageUrlList,
+                productImageUrls,
                 bidSummaryDto
         );
     }
@@ -103,13 +103,13 @@ public class AuctionService {
             Long sellerId,
             Pageable pageable
     ) {
-        List<Product> productList = productService.getProductListBySellerId(sellerId);
+        List<Product> products = productService.getProductListBySellerId(sellerId);
 
-        List<Long> productIdList = productList.stream()
+        List<Long> productIds = products.stream()
                 .map(Product::getProductId)
                 .toList();
 
-        Page<Auction> auctionPage = auctionRepository.findAllByProductIdIn(productIdList, pageable);
+        Page<Auction> auctionPage = auctionRepository.findAllByProductIdIn(productIds, pageable);
 
         Page<SellerSaleListResponse> sellerSaleListResponsePage = auctionPage
                 .map(auction -> {
@@ -143,9 +143,9 @@ public class AuctionService {
                 .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
     }
 
-    private List<String> getProductImageUrlList(Product product) {
+    private List<String> getProductImageUrls(Product product) {
         return productImageService.getByProduct(product)
-                .toProductImageUrlList();
+                .toProductImageUrls();
     }
 
     private Page<Auction> getAuctionPage(

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -5,13 +5,10 @@ import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
-import com.deal4u.fourplease.domain.bid.repository.BidRepository;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.settlement.repository.SettlementRepository;
 import com.deal4u.fourplease.domain.shipment.repository.ShipmentRepository;
 import com.deal4u.fourplease.global.exception.ErrorCode;
-import java.math.BigDecimal;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -26,9 +23,6 @@ public class AuctionSupportService {
     private final SettlementRepository settlementRepository;
     private final ShipmentRepository shipmentRepository;
 
-    // TODO: bidRepository가 아닌 bidService에서 불러오는 방식으로 수정 필요
-
-
     public Page<AuctionListResponse> getAuctionListResponses(Page<Auction> auctionPage) {
         return auctionPage
                 .map(auction -> {
@@ -37,7 +31,7 @@ public class AuctionSupportService {
                     return AuctionListResponse.toAuctionListResponse(
                             auction,
                             bidSummaryDto,
-                            // TODO: wishList 개발 후 수정 필요
+                            // TODO: wishlist 개발 후 수정 필요
                             false
                     );
                 });

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -8,6 +8,7 @@ import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.settlement.repository.SettlementRepository;
 import com.deal4u.fourplease.domain.shipment.repository.ShipmentRepository;
+import com.deal4u.fourplease.domain.wishlist.service.WishlistService;
 import com.deal4u.fourplease.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuctionSupportService {
 
     private final BidService bidService;
+    private final WishlistService wishlistService;
+
     private final SettlementRepository settlementRepository;
     private final ShipmentRepository shipmentRepository;
 
@@ -31,8 +34,7 @@ public class AuctionSupportService {
                     return AuctionListResponse.toAuctionListResponse(
                             auction,
                             bidSummaryDto,
-                            // TODO: wishlist 개발 후 수정 필요
-                            false
+                            wishlistService.isWishlist(auction)
                     );
                 });
     }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -6,6 +6,7 @@ import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
 import com.deal4u.fourplease.domain.bid.repository.BidRepository;
+import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.settlement.repository.SettlementRepository;
 import com.deal4u.fourplease.domain.shipment.repository.ShipmentRepository;
 import com.deal4u.fourplease.global.exception.ErrorCode;
@@ -21,23 +22,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AuctionSupportService {
 
-    private final BidRepository bidRepository;
+    private final BidService bidService;
     private final SettlementRepository settlementRepository;
     private final ShipmentRepository shipmentRepository;
 
     // TODO: bidRepository가 아닌 bidService에서 불러오는 방식으로 수정 필요
-    @Transactional(readOnly = true)
-    public BidSummaryDto getBidSummaryDto(Long auctionId) {
-        List<BigDecimal> bidList = bidRepository.findPricesByAuctionIdOrderByPriceDesc(
-                auctionId
-        );
-        return BidSummaryDto.toBidSummaryDto(bidList);
-    }
+
 
     public Page<AuctionListResponse> getAuctionListResponses(Page<Auction> auctionPage) {
         return auctionPage
                 .map(auction -> {
-                    BidSummaryDto bidSummaryDto = getBidSummaryDto(auction.getAuctionId());
+                    BidSummaryDto bidSummaryDto = bidService
+                            .getBidSummaryDto(auction.getAuctionId());
                     return AuctionListResponse.toAuctionListResponse(
                             auction,
                             bidSummaryDto,

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/ProductImageService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/ProductImageService.java
@@ -26,16 +26,16 @@ public class ProductImageService {
 
     @Transactional(readOnly = true)
     public ProductImageListResponse getByProduct(Product product) {
-        List<ProductImage> productImageList = findByProduct(product);
+        List<ProductImage> productImages = findByProduct(product);
 
-        return new ProductImageListResponse(productImageList);
+        return new ProductImageListResponse(productImages);
     }
 
     @Transactional
     public void deleteProductImage(Product product) {
-        List<ProductImage> targetProductImageList = findByProduct(product);
+        List<ProductImage> targetProductImages = findByProduct(product);
 
-        productImageRepository.deleteAll(targetProductImageList);
+        productImageRepository.deleteAll(targetProductImages);
     }
 
     private List<ProductImage> findByProduct(Product product) {

--- a/src/main/java/com/deal4u/fourplease/domain/auction/validator/Validator.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/validator/Validator.java
@@ -1,5 +1,7 @@
 package com.deal4u.fourplease.domain.auction.validator;
 
+import com.deal4u.fourplease.domain.auction.entity.Seller;
+import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.ErrorCode;
 import java.util.List;
 import lombok.experimental.UtilityClass;
@@ -10,6 +12,12 @@ public class Validator {
     public static void validateListNotEmpty(List<?> list) {
         if (list.isEmpty()) {
             throw ErrorCode.EMPTY_LIST.toException();
+        }
+    }
+
+    public static void validateSeller(Seller seller, Member member) {
+        if (!seller.getMember().equals(member)) {
+            throw ErrorCode.FORBIDDEN_RECEIVER.toException();
         }
     }
 

--- a/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
@@ -1,6 +1,7 @@
 package com.deal4u.fourplease.domain.bid.service;
 
 import com.deal4u.fourplease.config.BidWebSocketHandler;
+import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
@@ -17,6 +18,8 @@ import com.deal4u.fourplease.domain.member.repository.MemberRepository;
 import com.deal4u.fourplease.global.exception.ErrorCode;
 import com.deal4u.fourplease.global.lock.NamedLock;
 import com.deal4u.fourplease.global.lock.NamedLockProvider;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -124,6 +127,15 @@ public class BidService {
         } finally {
             lock.unlock();
         }
+    }
+
+    // bid maxprice와 bidCount를 반환
+    @Transactional(readOnly = true)
+    public BidSummaryDto getBidSummaryDto(Long auctionId) {
+        List<BigDecimal> bidList = bidRepository.findPricesByAuctionIdOrderByPriceDesc(
+                auctionId
+        );
+        return BidSummaryDto.toBidSummaryDto(bidList);
     }
 
     public PageResponse<BidResponse> getBidListForAuction(Long auctionId, Pageable pageable) {

--- a/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
@@ -129,7 +129,7 @@ public class BidService {
         }
     }
 
-    // bid maxprice와 bidCount를 반환
+    // bid max price와 bidCount를 반환
     @Transactional(readOnly = true)
     public BidSummaryDto getBidSummaryDto(Long auctionId) {
         List<BigDecimal> bidList = bidRepository.findPricesByAuctionIdOrderByPriceDesc(

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
@@ -41,7 +41,7 @@ public class WishlistController {
     private final WishlistService wishlistService;
 
     @Operation(summary = "위시리스트 추가")
-    @ApiResponse(responseCode = "200", description = "위시리스트 추가 성공")
+    @ApiResponse(responseCode = "201", description = "위시리스트 추가 성공")
     @ApiResponse(responseCode = "401", description = "인증 실패")
     @ApiResponse(responseCode = "403", description = "권한 없음")
     @PostMapping
@@ -72,6 +72,7 @@ public class WishlistController {
 
     @Operation(summary = "위시리스트 삭제")
     @ApiResponse(responseCode = "204", description = "위시리스트 삭제 성공")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
     @ApiResponse(responseCode = "404", description = "해당 위시리스트를 찾을 수 없음")
     @DeleteMapping("/{wishlistId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
@@ -77,9 +77,10 @@ public class WishlistController {
     @DeleteMapping("/{wishlistId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteWishlist(
-            @PathVariable(name = "wishlistId") @Positive Long wishlistId
+            @PathVariable(name = "wishlistId") @Positive Long wishlistId,
+            @AuthenticationPrincipal Member member
     ) {
-        wishlistService.deleteByWishlistId(wishlistId);
+        wishlistService.deleteByWishlistId(wishlistId, member);
     }
 
 }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
@@ -1,5 +1,6 @@
 package com.deal4u.fourplease.domain.wishlist.repository;
 
+import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,4 +16,5 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
             + "AND w.memberId = :memberId")
     Page<Wishlist> findAll(Pageable pageable, @Param("memberId") Long memberId);
 
+    boolean existsByAuctionAndDeletedFalse(Auction auction);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -1,9 +1,10 @@
 package com.deal4u.fourplease.domain.wishlist.service;
 
+import static com.deal4u.fourplease.domain.wishlist.validator.Validator.validateMember;
+
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
-import com.deal4u.fourplease.domain.auction.service.AuctionService;
-import com.deal4u.fourplease.domain.auction.service.AuctionSupportService;
+import com.deal4u.fourplease.domain.auction.service.AuctionReaderImpl;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
@@ -23,21 +24,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class WishlistService {
 
     private final WishlistRepository wishlistRepository;
-    private final AuctionService auctionService;
+    private final AuctionReaderImpl auctionReaderImpl;
     private final BidService bidService;
 
     @Transactional
     public Long save(WishlistCreateRequest request, Member member) {
-        Auction auction = auctionService.getAuctionByAuctionId(request.auctionId());
+        Auction auction = auctionReaderImpl.getAuctionByAuctionId(request.auctionId());
         Wishlist wishlist = request.toEntity(member, auction);
 
         return wishlistRepository.save(wishlist).getWishlistId();
     }
 
     @Transactional
-    public void deleteByWishlistId(Long wishlistId) {
+    public void deleteByWishlistId(Long wishlistId, Member member) {
         Wishlist targetWishlist = wishlistRepository.findById(wishlistId)
                 .orElseThrow(ErrorCode.WISHLIST_NOT_FOUND::toException);
+
+        validateMember(targetWishlist, member);
 
         targetWishlist.delete();
     }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -4,6 +4,7 @@ import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.auction.service.AuctionSupportService;
+import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.wishlist.dto.WishlistCreateRequest;
@@ -23,7 +24,7 @@ public class WishlistService {
 
     private final WishlistRepository wishlistRepository;
     private final AuctionService auctionService;
-    private final AuctionSupportService auctionSupportService;
+    private final BidService bidService;
 
     @Transactional
     public Long save(WishlistCreateRequest request, Member member) {
@@ -48,7 +49,7 @@ public class WishlistService {
         Page<WishlistResponse> wishlistResponsePage = wishlistPage
                 .map(wishlist -> {
                     BidSummaryDto bidSummaryDto =
-                            auctionSupportService.getBidSummaryDto(
+                            bidService.getBidSummaryDto(
                                     wishlist.getAuction().getAuctionId()
                             );
                     return WishlistResponse.toWishlistResponse(wishlist, bidSummaryDto);

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -57,4 +57,8 @@ public class WishlistService {
 
         return PageResponse.fromPage(wishlistResponsePage);
     }
+
+    public boolean isWishlist(Auction auction) {
+        return wishlistRepository.existsByAuctionAndDeletedFalse(auction);
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/validator/Validator.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/validator/Validator.java
@@ -1,0 +1,17 @@
+package com.deal4u.fourplease.domain.wishlist.validator;
+
+import com.deal4u.fourplease.domain.member.entity.Member;
+import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
+import com.deal4u.fourplease.global.exception.ErrorCode;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Validator {
+
+    public static void validateMember(Wishlist wishlist, Member member) {
+        if (!wishlist.getMemberId().equals(member.getMemberId())) {
+            throw ErrorCode.FORBIDDEN_RECEIVER.toException();
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 # application.yml의 경우 개발 시에 Local에서 사용하기 때문에,
 # gitIgnore을 통해서 제외하고 Commit해야합니다.
 # gitIgnore은 dev에서 설정해두었으나 git add 시에 한 번 확인해주세요.
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 900000   # 15분 (ms 단위)
+  refresh-token-expiration: 604800000 # 7일
+
 spring:
   datasource:
     url: jdbc:h2:mem:testdb
@@ -33,6 +38,36 @@ spring:
   h2:
     console:
       enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "http://localhost:8080/api/v1/login/google"
+            scope:
+              - email
+              - profile
+          naver:
+            client-id: ${NAVER_CLIENT_ID} # 발급 받은 Client ID
+            client-secret: ${NAVER_CLIENT_SECRET} # 발급 받은 Client Secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "http://localhost:8080/login/oauth2/code/naver"
+            scope:
+              - name
+              - email
+              - profile_image
+            client-name: Naver
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-info-authentication-method: header
+            user-name-attribute: response # Naver 응답 값 resultCode, message, response 중 response 지정
+
 toss:
   secret-key: ${TOSS_SECRET_KEY}
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -3,7 +3,9 @@ package com.deal4u.fourplease.domain.auction.controller;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionCreateRequest;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionDetailResponse;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionListResponsePageResponse;
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genMember;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -119,7 +121,7 @@ class AuctionControllerTests extends BaseTokenTest {
                 ).andExpect(status().isNoContent())
                 .andDo(print());
 
-        verify(auctionService).deleteByAuctionId(auctionId);
+        verify(auctionService).deleteByAuctionId(eq(auctionId), any(Member.class));
     }
 
     @Test

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -125,13 +125,13 @@ class AuctionServiceTests {
         Auction auction = genAuctionCreateRequest().toEntity(product);
 
         ProductImageListResponse productImageListResponse = mock(ProductImageListResponse.class);
-        List<String> productImageUrlList = List.of("http://example.com/image1.jpg",
+        List<String> productImageUrls = List.of("http://example.com/image1.jpg",
                 "http://example.com/image2.jpg");
 
         when(bidService.getBidSummaryDto(auctionId)).thenReturn(bidSummaryDto);
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.of(auction));
         when(productImageService.getByProduct(product)).thenReturn(productImageListResponse);
-        when(productImageListResponse.toProductImageUrlList()).thenReturn(productImageUrlList);
+        when(productImageListResponse.toProductImageUrls()).thenReturn(productImageUrls);
 
         AuctionDetailResponse actualResp = auctionService.getByAuctionId(auctionId);
 
@@ -144,8 +144,8 @@ class AuctionServiceTests {
         assertThat(actualResp.description()).isEqualTo(product.getDescription());
         assertThat(actualResp.endTime()).isEqualTo(auction.getDuration().getEndTime());
         assertThat(actualResp.thumbnailUrl()).isEqualTo(product.getThumbnailUrl());
-        assertThat(actualResp.imageUrls().getFirst()).isEqualTo(productImageUrlList.getFirst());
-        assertThat(actualResp.imageUrls().getLast()).isEqualTo(productImageUrlList.getLast());
+        assertThat(actualResp.imageUrls().getFirst()).isEqualTo(productImageUrls.getFirst());
+        assertThat(actualResp.imageUrls().getLast()).isEqualTo(productImageUrls.getLast());
 
     }
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -27,6 +27,7 @@ import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
+import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.GlobalException;
@@ -65,6 +66,9 @@ class AuctionServiceTests {
 
     @Mock
     private AuctionSupportService auctionSupportService;
+
+    @Mock
+    private BidService bidService;
 
     @Mock
     private AuctionScheduleService auctionScheduleService;
@@ -124,7 +128,7 @@ class AuctionServiceTests {
         List<String> productImageUrlList = List.of("http://example.com/image1.jpg",
                 "http://example.com/image2.jpg");
 
-        when(auctionSupportService.getBidSummaryDto(auctionId)).thenReturn(bidSummaryDto);
+        when(bidService.getBidSummaryDto(auctionId)).thenReturn(bidSummaryDto);
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.of(auction));
         when(productImageService.getByProduct(product)).thenReturn(productImageListResponse);
         when(productImageListResponse.toProductImageUrlList()).thenReturn(productImageUrlList);
@@ -207,7 +211,7 @@ class AuctionServiceTests {
         when(auctionRepository.findAllByProductIdIn(productIdList, pageable))
                 .thenReturn(auctionPage);
 
-        when(auctionSupportService.getBidSummaryDto(anyLong()))
+        when(bidService.getBidSummaryDto(anyLong()))
                 // id 별로 다른 값 반환
                 .thenAnswer(invocation -> {
                     Long auctionId = invocation.getArgument(0);

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/ProductImageServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/ProductImageServiceTests.java
@@ -66,7 +66,7 @@ class ProductImageServiceTests {
                 .thenReturn(productImageList);
 
         ProductImageListResponse actualResp = productImageService.getByProduct(product);
-        List<String> actualImageUrls = actualResp.toProductImageUrlList();
+        List<String> actualImageUrls = actualResp.toProductImageUrls();
 
         assertThat(actualImageUrls).containsExactly(
                 "http://example.com/image1.jpg",

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -19,6 +19,7 @@ import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.member.entity.Role;
 import com.deal4u.fourplease.domain.member.entity.Status;
 import com.deal4u.fourplease.domain.wishlist.dto.WishlistResponse;
+import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -361,6 +362,15 @@ public class TestUtils {
                 .totalPages(1)
                 .page(0)
                 .size(20)
+                .build();
+    }
+
+
+    public static Wishlist genWishlist(Long memberId) {
+        return Wishlist.builder()
+                .memberId(1L)
+                .auction(genAuction())
+                .deleted(false)
                 .build();
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistControllerTests.java
@@ -1,5 +1,6 @@
 package com.deal4u.fourplease.domain.wishlist.controller;
 
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genMember;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genWishlistResponsePageResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -124,6 +125,6 @@ class WishlistControllerTests extends BaseTokenTest {
                 ).andExpect(status().isNoContent())
                 .andDo(print());
 
-        verify(wishlistService).deleteByWishlistId(wishlistId);
+        verify(wishlistService).deleteByWishlistId(eq(wishlistId), any(Member.class));
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
@@ -11,6 +11,7 @@ import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.auction.service.AuctionSupportService;
+import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.wishlist.dto.WishlistCreateRequest;
@@ -44,7 +45,7 @@ class WishlistServiceTests {
     private AuctionService auctionService;
 
     @Mock
-    private AuctionSupportService auctionSupportService;
+    private BidService bidService;
 
     @Test
     @DisplayName("위시리스트를 등록할 수 있다")
@@ -114,7 +115,7 @@ class WishlistServiceTests {
 
         when(member.getMemberId()).thenReturn(1L);
         when(wishlistRepository.findAll(pageable, 1L)).thenReturn(wishlistPage);
-        when(auctionSupportService.getBidSummaryDto(auction.getAuctionId()))
+        when(bidService.getBidSummaryDto(auction.getAuctionId()))
                 .thenReturn(bidSummaryDto);
 
         PageResponse<WishlistResponse> resp = wishlistService.findAll(pageable, member);

--- a/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
@@ -1,19 +1,26 @@
 package com.deal4u.fourplease.domain.wishlist.service;
 
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuction;
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genMember;
+import static com.deal4u.fourplease.domain.auction.util.TestUtils.genWishlist;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.service.AuctionReaderImpl;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.auction.service.AuctionSupportService;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
+import com.deal4u.fourplease.domain.member.entity.Role;
+import com.deal4u.fourplease.domain.member.entity.Status;
 import com.deal4u.fourplease.domain.wishlist.dto.WishlistCreateRequest;
 import com.deal4u.fourplease.domain.wishlist.dto.WishlistResponse;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
@@ -21,6 +28,7 @@ import com.deal4u.fourplease.domain.wishlist.repository.WishlistRepository;
 import com.deal4u.fourplease.global.exception.GlobalException;
 import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +40,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+@Slf4j
 @ExtendWith(MockitoExtension.class)
 class WishlistServiceTests {
 
@@ -42,7 +51,7 @@ class WishlistServiceTests {
     private WishlistRepository wishlistRepository;
 
     @Mock
-    private AuctionService auctionService;
+    private AuctionReaderImpl auctionReaderImpl;
 
     @Mock
     private BidService bidService;
@@ -58,7 +67,7 @@ class WishlistServiceTests {
         Wishlist wishlist = mock(Wishlist.class);
 
         when(req.auctionId()).thenReturn(1L);
-        when(auctionService.getAuctionByAuctionId(1L)).thenReturn(auction);
+        when(auctionReaderImpl.getAuctionByAuctionId(1L)).thenReturn(auction);
         when(req.toEntity(member, auction)).thenReturn(wishlist);
         when(wishlist.getWishlistId()).thenReturn(1L);
         when(wishlistRepository.save(wishlist)).thenReturn(wishlist);
@@ -74,12 +83,16 @@ class WishlistServiceTests {
     void deleteShouldDeleteWishlistByWishlistId() {
 
         Long wishlistId = 1L;
-        Wishlist wishlist = mock(Wishlist.class);
+        Member member = Member.builder()
+                .memberId(1L)
+                .build();
+        Wishlist wishlist = genWishlist(member.getMemberId());
 
         when(wishlistRepository.findById(wishlistId)).thenReturn(Optional.of(wishlist));
 
-        wishlistService.deleteByWishlistId(wishlistId);
-        verify(wishlist).delete();
+        wishlistService.deleteByWishlistId(wishlistId, member);
+
+        assertThat(wishlist.isDeleted()).isTrue();
 
     }
 
@@ -91,9 +104,26 @@ class WishlistServiceTests {
 
         assertThatThrownBy(
                 () -> {
-                    wishlistService.deleteByWishlistId(1L);
+                    wishlistService.deleteByWishlistId(1L, genMember());
                 }
         ).isInstanceOf(GlobalException.class).hasMessage("해당 위시리스트를 찾을 수 없습니다.");
+
+    }
+
+    @Test
+    @DisplayName("일치하지 않는 사용자가 위시리스트 삭제를 시도하면 예외가 발생한다")
+    void throwsIfTryToDeleteWishlistByDifferentMember() {
+
+        Long wishlistId = 1L;
+        Wishlist wishlist = genWishlist(99L);
+
+        when(wishlistRepository.findById(wishlistId)).thenReturn(Optional.of(wishlist));
+
+        assertThatThrownBy(
+                () -> {
+                    wishlistService.deleteByWishlistId(wishlistId, genMember());
+                }
+        ).isInstanceOf(GlobalException.class).hasMessage("권한이 없습니다.");
 
     }
 

--- a/src/test/java/com/deal4u/fourplease/global/scheduler/AuctionScheduleServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/global/scheduler/AuctionScheduleServiceTest.java
@@ -13,6 +13,7 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.Product;
+import com.deal4u.fourplease.domain.auction.entity.Seller;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.auction.service.ProductService;
@@ -89,15 +90,17 @@ class AuctionScheduleServiceTest {
     void delete_by_auction_id_should_delete_auction_and_cancel_schedule() {
         // Given
         Long auctionId = 1L;
+        Product product = genProduct();
+        Seller seller = product.getSeller();
         Auction auction = Auction.builder()
                 .auctionId(auctionId)
-                .product(genProduct())
+                .product(product)
                 .build();
 
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.of(auction));
 
         // when
-        auctionService.deleteByAuctionId(auctionId);
+        auctionService.deleteByAuctionId(auctionId, seller.getMember());
 
         // then - schedule
         verify(auctionScheduleService, times(1)).cancelAuctionClose(auctionId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #63

## 📝 작업 내용
- 경매 및 위시리스트 삭제 시도 시 멤버 검증 로직 추가
- Seller에서 CaseCade 삭제
- -list -> -s로 네이밍 변경
- AuctionSupportService에서 BidRespository가 아닌 BidService를 의존 받도록 수정
- AuctionService -> AuctionSupportService -> WishlistService -> AuctionService 의존성 순환 해결을 위해 AuctionReader, AuctionReaderImpl 추가


## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?