### PR TITLE
fix(69): api 명세서에 따라 successhandler 수정 

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auth/handler/Oauth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auth/handler/Oauth2AuthenticationSuccessHandler.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 public class Oauth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
-    private static final String SIGNUP_REDIRECT_URL = "/signup";
+    private static final String SIGNUP_REDIRECT_URL = "api/v1/signup";
     private static final String MAIN_REDIRECT_URL = "/";
     private final JwtProvider jwtProvider;
     private final AuthService authService;
@@ -42,35 +42,31 @@ public class Oauth2AuthenticationSuccessHandler implements AuthenticationSuccess
         log.info("멤버 이메일: " + member.getEmail());
         log.info("멤버 상태: " + member.getStatus());
 
-        response.setStatus(HttpServletResponse.SC_OK);
 
         if (member.getStatus() == Status.PENDING) {
+            // 로그인 실패
             // 아직 닉네임 설정 안했으므로, 프론트 닉네임 설정 페이지로 redirect
-            String tempToken = jwtProvider.generateTokenPair(member).accessToken(); // 임시 토큰 발급
-            log.info("임시 token: " + tempToken);
-            response.setHeader("Authorization", "Bearer " + tempToken);
-            response.setHeader("X-Redirect-Url", SIGNUP_REDIRECT_URL);
-        } else {
-            // 새로운 JWT 발급
-            TokenPair tokenPair = authService.createTokenPair(member);
-            response.setHeader("Authorization", "Bearer " + tokenPair.accessToken());
-            ResponseCookie refreshCookie = ResponseCookie
-                    .from("refreshToken", tokenPair.refreshToken())
-                    .httpOnly(true)
-                    .secure(false) // 운영 환경에서는 true
-                    .path("/")
-                    .sameSite("Lax") // 운영 환경에서는 Strict
-                    .maxAge(Duration.ofHours(1))
-                    .build();
-            response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-            log.info("Access token: " + tokenPair.accessToken());
-            log.info("RefreshToken 쿠키 설정 완료: {}", refreshCookie);
-
-            response.setHeader("X-Redirect-Url", MAIN_REDIRECT_URL);
+            String token = jwtProvider.generateTokenPair(member).accessToken();
+            String redirectUrl = SIGNUP_REDIRECT_URL + "/" + token;
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(String.format("{\"redirect\":\"%s\"}", redirectUrl));
+            response.getWriter().flush();
         }
-
-        response.getWriter().write("{\"status\":\"ok\"}");
-        response.getWriter().flush();
-
+        // 로그인 성공
+        // 새로운 JWT 발급
+        TokenPair tokenPair = authService.createTokenPair(member);
+        response.setHeader("Authorization", "Bearer " + tokenPair.accessToken());
+        ResponseCookie refreshCookie = ResponseCookie
+                .from("refreshToken", tokenPair.refreshToken())
+                .httpOnly(true)
+                .secure(false) // 운영 환경에서는 true
+                .path("/")
+                .sameSite("Lax") // 운영 환경에서는 Strict
+                .maxAge(Duration.ofHours(1))
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        response.setStatus(HttpServletResponse.SC_OK);
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auth/handler/Oauth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auth/handler/Oauth2AuthenticationSuccessHandler.java
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class Oauth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
     private static final String SIGNUP_REDIRECT_URL = "api/v1/signup";
-    private static final String MAIN_REDIRECT_URL = "/";
     private final JwtProvider jwtProvider;
     private final AuthService authService;
     private final MemberService memberService;
@@ -53,6 +52,7 @@ public class Oauth2AuthenticationSuccessHandler implements AuthenticationSuccess
             response.setCharacterEncoding("UTF-8");
             response.getWriter().write(String.format("{\"redirect\":\"%s\"}", redirectUrl));
             response.getWriter().flush();
+            return;
         }
         // 로그인 성공
         // 새로운 JWT 발급

--- a/src/test/java/com/deal4u/fourplease/domain/auth/handler/Oauth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auth/handler/Oauth2AuthenticationSuccessHandlerTest.java
@@ -55,7 +55,6 @@ class Oauth2AuthenticationSuccessHandlerTest {
 
         when(authentication.getPrincipal()).thenReturn(customOauth2User);
         when(customOauth2User.getMember()).thenReturn(member);
-        when(response.getWriter()).thenReturn(new PrintWriter(outputStream, true));
     }
 
     @Test
@@ -63,6 +62,7 @@ class Oauth2AuthenticationSuccessHandlerTest {
     void onAuthenticationSuccessPendingStatusReturnsTempTokenAndRedirectToSignup()
             throws Exception {
         // given
+        when(response.getWriter()).thenReturn(new PrintWriter(outputStream, true));
         String tempToken = "temp.jwt.token";
         when(member.getStatus()).thenReturn(Status.PENDING);
         when(jwtProvider.generateTokenPair(member)).thenReturn(
@@ -73,10 +73,9 @@ class Oauth2AuthenticationSuccessHandlerTest {
         successHandler.onAuthenticationSuccess(request, response, authentication);
 
         // then
-        verify(response).setHeader("Authorization", "Bearer " + tempToken);
-        verify(response).setHeader("X-Redirect-Url", "/signup");
-        verify(response).setStatus(HttpServletResponse.SC_OK);
-        assertThat(outputStream.toString()).contains("{\"status\":\"ok\"}");
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        String expectedRedirectJson = String.format("{\"redirect\":\"api/v1/signup/%s\"}", tempToken);
+        assertThat(outputStream.toString()).contains(expectedRedirectJson);
     }
 
     @Test
@@ -96,8 +95,7 @@ class Oauth2AuthenticationSuccessHandlerTest {
         // then
         verify(response).setHeader("Authorization", "Bearer " + accessToken);
         verify(response).addHeader(eq("Set-Cookie"), contains("refreshToken=")); // 쿠키 확인
-        verify(response).setHeader("X-Redirect-Url", "/");
         verify(response).setStatus(HttpServletResponse.SC_OK);
-        assertThat(outputStream.toString()).contains("{\"status\":\"ok\"}");
+        assertThat(outputStream.toString()).isBlank();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #69 

## 📝 작업 내용
- api명세서에 따라 로그인 성공 시 200, 실패 시 401과 응답 바디를 통해 회원 가입 redirecturl 넘겨줍니다.

## ✅ 피드백 반영사항
- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제)

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?