### PR TITLE
feat(80): 특정 상품의 판매자 정보 조회 로직 작성

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -5,6 +5,7 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionImageUrlResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionSearchRequest;
+import com.deal4u.fourplease.domain.auction.dto.SellerInfoResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.auction.service.SaveAuctionImageService;
 import com.deal4u.fourplease.domain.common.PageResponse;
@@ -101,4 +102,13 @@ public class AuctionController {
         return saveAuctionImageService.upload(memberRepository.findAll().getFirst(), image);
     }
 
+    @Operation(summary = "특정 상품의 판매자 정보 조회")
+    @ApiResponse(responseCode = "200", description = "판매자 정보 반환 성공")
+    @ApiResponse(responseCode = "404", description = "경매나 판매자 정보를 찾을 수 없음")
+    @GetMapping("/{auctionId}/seller")
+    @ResponseStatus(HttpStatus.OK)
+    public SellerInfoResponse getSellerInfo(
+            @PathVariable(name = "auctionId") @Positive Long auctionId) {
+        return auctionService.getSellerInfo(auctionId);
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerInfoResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerInfoResponse.java
@@ -1,0 +1,11 @@
+package com.deal4u.fourplease.domain.auction.dto;
+
+public record SellerInfoResponse(
+        Long sellerId,
+        String sellerNickname,
+        Integer totalReviews,
+        Double averageRating,
+        Integer completedDeals,
+        String createdAt
+) {
+}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -1,6 +1,7 @@
 package com.deal4u.fourplease.domain.auction.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,15 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "JOIN FETCH a.product "
             + "WHERE a.auctionId = :auctionId")
     Optional<Auction> findByIdWithProduct(@Param("auctionId") Long auctionId);
+
+    @Query("SELECT a "
+            + "FROM Auction a "
+            + "JOIN FETCH a.product p "
+            + "JOIN FETCH p.seller s "
+            + "JOIN FETCH s.member m "
+            + "WHERE a.auctionId = :auctionId")
+    Optional<Auction> findByIdWithProductAndSellerAndMember(@Param("auctionId") Long auctionId);
+
 
     @Query("SELECT a "
             + "FROM Auction a "
@@ -127,4 +137,8 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             @Param("categoryId") Long categoryId,
             Pageable pageable
     );
+
+    @Query("SELECT COUNT(a) FROM Auction a WHERE a.product.seller.member.memberId = :sellerId AND a.status = :status")
+    Integer countBySellerIdAndStatus(@Param("sellerId") Long sellerId,
+                                     @Param("status") AuctionStatus status);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -1,6 +1,7 @@
 package com.deal4u.fourplease.domain.auction.service;
 
 import static com.deal4u.fourplease.domain.auction.validator.Validator.validateSeller;
+import static com.deal4u.fourplease.global.exception.ErrorCode.AUCTION_NOT_FOUND;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
@@ -8,15 +9,17 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionSearchRequest;
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
+import com.deal4u.fourplease.domain.auction.dto.SellerInfoResponse;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.Product;
-import com.deal4u.fourplease.domain.auction.reader.AuctionReader;
+import com.deal4u.fourplease.domain.auction.entity.Seller;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
-import com.deal4u.fourplease.global.exception.ErrorCode;
+import com.deal4u.fourplease.domain.review.repository.ReviewRepository;
 import com.deal4u.fourplease.global.scheduler.AuctionScheduleService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +39,7 @@ public class AuctionService {
     private final ProductService productService;
     private final ProductImageService productImageService;
     private final AuctionScheduleService auctionScheduleService;
+    private final ReviewRepository reviewRepository;
 
     private final BidService bidService;
 
@@ -59,7 +63,7 @@ public class AuctionService {
         BidSummaryDto bidSummaryDto = bidService.getBidSummaryDto(auctionId);
 
         Auction auction = auctionRepository.findByIdWithProduct(auctionId)
-                .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
+                .orElseThrow(AUCTION_NOT_FOUND::toException);
 
         List<String> productImageUrls = getProductImageUrls(auction.getProduct());
 
@@ -73,7 +77,7 @@ public class AuctionService {
     @Transactional
     public void deleteByAuctionId(Long auctionId, Member member) {
         Auction targetAuction = auctionRepository.findByIdWithProduct(auctionId)
-                .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
+                .orElseThrow(AUCTION_NOT_FOUND::toException);
 
         // TODO: Auction status 업데이트 후 낙찰된 경매는 취소 불가 기능 추가
 
@@ -140,6 +144,38 @@ public class AuctionService {
     @Transactional
     public void fail(Auction auction) {
         auction.fail();
+    }
+
+    @Transactional(readOnly = true)
+    public SellerInfoResponse getSellerInfo(Long auctionId) {
+        Auction auction = getAuctionOrThrow(auctionId);
+
+        Seller seller = auction.getProduct().getSeller();
+
+        Long sellerId = seller.getMember().getMemberId();
+        String sellerNickname = seller.getMember().getNickName();
+        String createdAt = seller.getMember().getCreatedAt().toString();
+
+        Integer totalReviews = reviewRepository.countBySellerMemberId(sellerId);
+        Double averageRating = reviewRepository.getAverageRatingBySellerMemberId(sellerId);
+        averageRating = averageRating != null ? averageRating : 0.0;
+
+        Integer completedDeals =
+                auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED);
+
+        return new SellerInfoResponse(
+                sellerId,
+                sellerNickname,
+                totalReviews,
+                Math.round(averageRating * 100.0) / 100.0,
+                completedDeals,
+                createdAt
+        );
+    }
+
+    private Auction getAuctionOrThrow(Long auctionId) {
+        return auctionRepository.findByIdWithProductAndSellerAndMember(auctionId)
+                .orElseThrow(AUCTION_NOT_FOUND::toException);
     }
 
     private List<String> getProductImageUrls(Product product) {

--- a/src/main/java/com/deal4u/fourplease/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/review/repository/ReviewRepository.java
@@ -17,4 +17,12 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("select r from Review r where r.seller = :seller")
     Page<Review> findBySeller(@Param("seller") Seller seller, Pageable pageable);
+
+    // 판매자별 리뷰 개수
+    @Query("SELECT COUNT(r) FROM Review r WHERE r.seller.member.memberId = :sellerId")
+    Integer countBySellerMemberId(@Param("sellerId") Long sellerId);
+
+    // 판매자별 평균 평점
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.seller.member.memberId = :sellerId")
+    Double getAverageRatingBySellerMemberId(@Param("sellerId") Long sellerId);
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -21,6 +21,7 @@ import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.dto.CategoryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductImageListResponse;
+import com.deal4u.fourplease.domain.auction.dto.SellerInfoResponse;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
@@ -31,6 +32,7 @@ import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
+import com.deal4u.fourplease.domain.review.repository.ReviewRepository;
 import com.deal4u.fourplease.global.exception.GlobalException;
 import com.deal4u.fourplease.global.scheduler.AuctionScheduleService;
 import java.math.BigDecimal;
@@ -49,6 +51,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionServiceTests {
@@ -67,6 +71,9 @@ class AuctionServiceTests {
 
     @Mock
     private AuctionSupportService auctionSupportService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @Mock
     private BidService bidService;
@@ -279,7 +286,7 @@ class AuctionServiceTests {
         assertThat(auction.getStatus()).isEqualTo(AuctionStatus.OPEN);
 
         auctionService.close(auction);
-        
+
         assertThat(auction.getStatus()).isEqualTo(AuctionStatus.CLOSED);
 
     }
@@ -393,4 +400,178 @@ class AuctionServiceTests {
 
     }
 
+    @Test
+    @DisplayName("auctionId로 판매자 정보를 조회한다")
+    void getSellerInfoShouldReturnSellerInfoResponse() {
+        // Given
+        Long auctionId = 1L;
+        Long sellerId = 100L;
+        String sellerNickname = "박유한";
+        LocalDateTime createdAt = LocalDateTime.of(2000, 5, 25, 10, 0, 0);
+
+        Member member = Member.builder()
+                .memberId(sellerId)
+                .nickName(sellerNickname)
+                .email("test@example.com")
+                .provider("google")
+                .build();
+
+        ReflectionTestUtils.setField(member, "createdAt", createdAt);
+
+        Seller seller = Seller.create(member);
+
+        Product product = Product.builder()
+                .seller(seller)
+                .build();
+
+        Auction auction = Auction.builder()
+                .auctionId(auctionId)
+                .product(product)
+                .build();
+
+        Integer totalReviews = 25;
+        Double averageRating = 4.7;
+        Integer completedDeals = 18;
+
+        when(auctionRepository.findByIdWithProductAndSellerAndMember(auctionId)).thenReturn(
+                Optional.of(auction));
+        when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
+        when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(
+                averageRating);
+        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED))
+                .thenReturn(completedDeals);
+
+        // When
+        SellerInfoResponse response = auctionService.getSellerInfo(auctionId);
+
+        // Then
+        assertThat(response.sellerId()).isEqualTo(sellerId);
+        assertThat(response.sellerNickname()).isEqualTo(sellerNickname);
+        assertThat(response.totalReviews()).isEqualTo(totalReviews);
+        assertThat(response.averageRating()).isEqualTo(4.7);
+        assertThat(response.completedDeals()).isEqualTo(completedDeals);
+        assertThat(response.createdAt()).isEqualTo(createdAt.toString());
+    }
+
+    @Test
+    @DisplayName("리뷰가 없는 판매자의 평균 평점은 0.0으로 반환된다")
+    void getSellerInfoShouldReturnZeroRatingWhenNoReviews() {
+        // Given
+        Long auctionId = 1L;
+        Long sellerId = 100L;
+        String sellerNickname = "박유한";
+        LocalDateTime createdAt = LocalDateTime.of(2000, 5, 25, 10, 0, 0);
+
+        Member member = Member.builder()
+                .memberId(sellerId)
+                .nickName(sellerNickname)
+                .email("test@example.com")
+                .provider("google")
+                .build();
+
+        ReflectionTestUtils.setField(member, "createdAt", createdAt);
+
+        Seller seller = Seller.create(member);
+
+        Product product = Product.builder()
+                .seller(seller)
+                .build();
+
+        Auction auction = Auction.builder()
+                .auctionId(auctionId)
+                .product(product)
+                .build();
+
+        Integer totalReviews = 0;
+        Double averageRating = null; // 리뷰가 없을 때 null 반환
+        Integer completedDeals = 2;
+
+        when(auctionRepository.findByIdWithProductAndSellerAndMember(auctionId)).thenReturn(
+                Optional.of(auction));
+        when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
+        when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(averageRating);
+        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED))
+                .thenReturn(completedDeals);
+
+        // When
+        SellerInfoResponse response = auctionService.getSellerInfo(auctionId);
+
+        // Then
+        assertThat(response.sellerId()).isEqualTo(sellerId);
+        assertThat(response.sellerNickname()).isEqualTo(sellerNickname);
+        assertThat(response.totalReviews()).isEqualTo(totalReviews);
+        assertThat(response.averageRating()).isEqualTo(0.0);
+        assertThat(response.completedDeals()).isEqualTo(completedDeals);
+        assertThat(response.createdAt()).isEqualTo(createdAt.toString());
+    }
+
+
+    @Test
+    @DisplayName("평균 평점이 소수점 둘째 자리까지 반올림되어 반환된다")
+    void getSellerInfoShouldRoundAverageRatingToTwoDecimalPlaces() {
+        // Given
+        Long auctionId = 1L;
+        Long sellerId = 100L;
+        String sellerNickname = "박유한";
+        LocalDateTime createdAt = LocalDateTime.of(2000, 5, 25, 10, 0, 0);
+
+        Member member = Member.builder()
+                .memberId(sellerId)
+                .nickName(sellerNickname)
+                .email("test@example.com")
+                .provider("google")
+                .build();
+
+        ReflectionTestUtils.setField(member, "createdAt", createdAt);
+
+        Seller seller = Seller.create(member);
+
+        Product product = Product.builder()
+                .seller(seller)
+                .build();
+
+        Auction auction = Auction.builder()
+                .auctionId(auctionId)
+                .product(product)
+                .build();
+
+        Integer totalReviews = 127;
+        Double averageRating = 4.6789; // 소수점 넷째 자리까지 있는 평점
+        Integer completedDeals = 89;
+
+        when(auctionRepository.findByIdWithProductAndSellerAndMember(auctionId)).thenReturn(
+                Optional.of(auction));
+        when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
+        when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(averageRating);
+        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED))
+                .thenReturn(completedDeals);
+
+        // When
+        SellerInfoResponse response = auctionService.getSellerInfo(auctionId);
+
+        // Then
+        assertThat(response.sellerId()).isEqualTo(sellerId);
+        assertThat(response.sellerNickname()).isEqualTo(sellerNickname);
+        assertThat(response.totalReviews()).isEqualTo(totalReviews);
+        assertThat(response.averageRating()).isEqualTo(4.68); // 소수점 둘째 자리까지 반올림
+        assertThat(response.completedDeals()).isEqualTo(completedDeals);
+        assertThat(response.createdAt()).isEqualTo(createdAt.toString());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 auctionId로 판매자 정보 조회를 시도하면 404 예외가 발생한다")
+    void getSellerInfoShouldThrowExceptionWhenAuctionNotFound() {
+        // Given
+        Long auctionId = 999L;
+
+        when(auctionRepository.findByIdWithProductAndSellerAndMember(auctionId)).thenReturn(
+                Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> auctionService.getSellerInfo(auctionId))
+                .isInstanceOf(GlobalException.class)
+                .hasMessage("해당 경매를 찾을 수 없습니다.")
+                .extracting("status")
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
* #80 

## 📝 작업 내용
- 특정 상품의 판매자 정보 조회 로직 작성
- 특정 상품의 판매자 정보를 조회합니다. 최근 리뷰를 보여주는 로직은 삭제하였고 판매자 id, 닉네임, 지금까지 판매한 auction(close)된 갯수, 가입일을 반환하게 하였습니다. 

## ✅ 피드백 반영사항
- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제)

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?