### PR TITLE
feat(83) : 관심목록 삭제 시, AuctionId를 받도록 수정

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
@@ -74,13 +74,13 @@ public class WishlistController {
     @ApiResponse(responseCode = "204", description = "위시리스트 삭제 성공")
     @ApiResponse(responseCode = "403", description = "권한 없음")
     @ApiResponse(responseCode = "404", description = "해당 위시리스트를 찾을 수 없음")
-    @DeleteMapping("/{wishlistId}")
+    @DeleteMapping("/{auctionId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteWishlist(
-            @PathVariable(name = "wishlistId") @Positive Long wishlistId,
+            @PathVariable(name = "auctionId") @Positive Long auctionId,
             @AuthenticationPrincipal Member member
     ) {
-        wishlistService.deleteByWishlistId(wishlistId, member);
+        wishlistService.deleteByWishlistId(auctionId, member);
     }
 
 }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
@@ -2,6 +2,8 @@ package com.deal4u.fourplease.domain.wishlist.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
+import java.util.Optional;
+import javax.swing.text.html.Option;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +19,12 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
     Page<Wishlist> findAll(Pageable pageable, @Param("memberId") Long memberId);
 
     boolean existsByAuctionAndDeletedFalse(Auction auction);
+
+    @Query("SELECT w "
+            + "FROM Wishlist w "
+            + "WHERE w.deleted = false "
+            + "AND w.auction = :auction "
+            + "AND w.memberId = :memberId")
+    Optional<Wishlist> findWishlist(@Param("auction") Auction auction,
+            @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -36,8 +36,11 @@ public class WishlistService {
     }
 
     @Transactional
-    public void deleteByWishlistId(Long wishlistId, Member member) {
-        Wishlist targetWishlist = wishlistRepository.findById(wishlistId)
+    public void deleteByWishlistId(Long auctionId, Member member) {
+        Auction auction = auctionReaderImpl.getAuctionByAuctionId(auctionId);
+
+        Wishlist targetWishlist = wishlistRepository.findWishlist(
+                        auction, member.getMemberId())
                 .orElseThrow(ErrorCode.WISHLIST_NOT_FOUND::toException);
 
         validateMember(targetWishlist, member);

--- a/src/test/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistControllerTests.java
@@ -1,6 +1,5 @@
 package com.deal4u.fourplease.domain.wishlist.controller;
 
-import static com.deal4u.fourplease.domain.auction.util.TestUtils.genMember;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genWishlistResponsePageResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -115,16 +114,16 @@ class WishlistControllerTests extends BaseTokenTest {
 
 
     @Test
-    @DisplayName("DELETE /api/v1/wishlist/{wishlistId}가 성공하면 wishlist를 삭제하고 204를 반환한다")
+    @DisplayName("DELETE /api/v1/wishlist/{auctionId}가 성공하면 wishlist를 삭제하고 204를 반환한다")
     void deleteWishlistShouldReturn204() throws Exception {
 
-        Long wishlistId = 1L;
+        Long auctionId = 1L;
 
         mockMvc.perform(
-                        delete("/api/v1/wishlist/{wishlistId}", wishlistId)
+                        delete("/api/v1/wishlist/{auctionId}", auctionId)
                 ).andExpect(status().isNoContent())
                 .andDo(print());
 
-        verify(wishlistService).deleteByWishlistId(eq(wishlistId), any(Member.class));
+        verify(wishlistService).deleteByWishlistId(eq(auctionId), any(Member.class));
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
@@ -2,10 +2,8 @@ package com.deal4u.fourplease.domain.wishlist.service;
 
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuction;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genMember;
-import static com.deal4u.fourplease.domain.auction.util.TestUtils.genWishlist;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -14,13 +12,9 @@ import static org.mockito.Mockito.when;
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.service.AuctionReaderImpl;
-import com.deal4u.fourplease.domain.auction.service.AuctionService;
-import com.deal4u.fourplease.domain.auction.service.AuctionSupportService;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
-import com.deal4u.fourplease.domain.member.entity.Role;
-import com.deal4u.fourplease.domain.member.entity.Status;
 import com.deal4u.fourplease.domain.wishlist.dto.WishlistCreateRequest;
 import com.deal4u.fourplease.domain.wishlist.dto.WishlistResponse;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
@@ -82,15 +76,21 @@ class WishlistServiceTests {
     @DisplayName("위시리스트를 삭제할 수 있다")
     void deleteShouldDeleteWishlistByWishlistId() {
 
-        Long wishlistId = 1L;
+        Long auctionId = 1L;
         Member member = Member.builder()
                 .memberId(1L)
                 .build();
-        Wishlist wishlist = genWishlist(member.getMemberId());
+        Auction auction = genAuction();
 
-        when(wishlistRepository.findById(wishlistId)).thenReturn(Optional.of(wishlist));
+        Wishlist wishlist = Wishlist.builder().auction(auction).memberId(member.getMemberId())
+                .deleted(false).build();
 
-        wishlistService.deleteByWishlistId(wishlistId, member);
+        when(auctionReaderImpl.getAuctionByAuctionId(auctionId)).thenReturn(auction);
+
+        when(wishlistRepository.findWishlist(eq(auction), eq(member.getMemberId())))
+                .thenReturn(Optional.of(wishlist));
+
+        wishlistService.deleteByWishlistId(auctionId, member);
 
         assertThat(wishlist.isDeleted()).isTrue();
 
@@ -100,11 +100,18 @@ class WishlistServiceTests {
     @DisplayName("존재하지 않는 위시리스트 삭제를 시도하면 예외가 발생한다")
     void throwsIfWishlistIdNotExist() {
 
-        when(wishlistRepository.findById(1L)).thenReturn(Optional.empty());
+        Long auctionId = 1L;
+        Member member = genMember();
+        Auction auction = genAuction();
+
+        when(auctionReaderImpl.getAuctionByAuctionId(auctionId)).thenReturn(auction);
+
+        when(wishlistRepository.findWishlist(eq(auction), eq(member.getMemberId())))
+                .thenReturn(Optional.empty());
 
         assertThatThrownBy(
                 () -> {
-                    wishlistService.deleteByWishlistId(1L, genMember());
+                    wishlistService.deleteByWishlistId(auctionId, genMember());
                 }
         ).isInstanceOf(GlobalException.class).hasMessage("해당 위시리스트를 찾을 수 없습니다.");
 
@@ -114,14 +121,25 @@ class WishlistServiceTests {
     @DisplayName("일치하지 않는 사용자가 위시리스트 삭제를 시도하면 예외가 발생한다")
     void throwsIfTryToDeleteWishlistByDifferentMember() {
 
-        Long wishlistId = 1L;
-        Wishlist wishlist = genWishlist(99L);
+        Long auctionId = 1L;
+        Member currentMember = Member.builder().memberId(1L).build();
+        Member wishlistOwner = Member.builder().memberId(99L).build();
+        Auction auction = genAuction();
 
-        when(wishlistRepository.findById(wishlistId)).thenReturn(Optional.of(wishlist));
+        Wishlist wishlist = Wishlist.builder()
+                .auction(auction)
+                .memberId(wishlistOwner.getMemberId())
+                .deleted(false)
+                .build();
+
+        when(auctionReaderImpl.getAuctionByAuctionId(auctionId)).thenReturn(auction);
+
+        when(wishlistRepository.findWishlist(eq(auction), eq(currentMember.getMemberId())))
+                .thenReturn(Optional.of(wishlist));
 
         assertThatThrownBy(
                 () -> {
-                    wishlistService.deleteByWishlistId(wishlistId, genMember());
+                    wishlistService.deleteByWishlistId(auctionId, currentMember);
                 }
         ).isInstanceOf(GlobalException.class).hasMessage("권한이 없습니다.");
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #83 

## 📝 작업 내용
- 기존 wishListId를 받던 Controller를 auctionId를 받도록 수정.
```
    @Operation(summary = "위시리스트 삭제")
    @ApiResponse(responseCode = "204", description = "위시리스트 삭제 성공")
    @ApiResponse(responseCode = "403", description = "권한 없음")
    @ApiResponse(responseCode = "404", description = "해당 위시리스트를 찾을 수 없음")
    @DeleteMapping("/{auctionId}")
    @ResponseStatus(HttpStatus.NO_CONTENT)
    public void deleteWishlist(
            @PathVariable(name = "auctionId") @Positive Long auctionId,
            @AuthenticationPrincipal Member member
    ) {
        wishlistService.deleteByWishlistId(auctionId, member);
    }
```

또한, 서비스와 Test상에서도 auctionId를 받도록 수정하였습니다.

## ✅ 피드백 반영사항
- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제)

## 📸 스크린샷 (선택)

<img width="891" height="159" alt="image" src="https://github.com/user-attachments/assets/cc9586d9-e232-4067-a9f4-34e193de02c6" />


<img width="764" height="213" alt="image" src="https://github.com/user-attachments/assets/8855fea7-d49c-4af3-95d9-723a1d8b34bf" />


## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?