### PR TITLE
refactor(82): 경매/위시리스트 성능 개선 및 버그 수정 - 정미광

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -51,9 +51,10 @@ public class AuctionController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public PageResponse<AuctionListResponse> readAllAuctions(
-            @Valid @ModelAttribute @ParameterObject AuctionSearchRequest request
+            @Valid @ModelAttribute @ParameterObject AuctionSearchRequest request,
+            @AuthenticationPrincipal Member member
     ) {
-        return auctionService.findAll(request);
+        return auctionService.findAll(request, member);
     }
 
     @Operation(summary = "경매등록")

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/SellerSaleListResponse.java
@@ -2,7 +2,6 @@ package com.deal4u.fourplease.domain.auction.dto;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.Product;
-import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
 import java.math.BigDecimal;
 
 public record SellerSaleListResponse(
@@ -23,8 +22,7 @@ public record SellerSaleListResponse(
 
     public static SellerSaleListResponse toSellerSaleListResponse(
             Auction auction,
-            BidSummaryDto bidSummaryDto,
-            SaleAuctionStatus status
+            BidSummaryDto bidSummaryDto
     ) {
         Product product = auction.getProduct();
         return new SellerSaleListResponse(
@@ -35,7 +33,7 @@ public record SellerSaleListResponse(
                 auction.getStartingPrice(),
                 product.getDescription(),
                 bidSummaryDto.bidCount(),
-                status.toString()
+                auction.getStatus().name()
         );
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/entity/Auction.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/entity/Auction.java
@@ -52,7 +52,7 @@ public class Auction extends BaseDateEntity {
     private boolean deleted;
 
     public void close() {
-        this.status = AuctionStatus.CLOSED;
+        this.status = AuctionStatus.CLOSE;
     }
 
     public void fail() {

--- a/src/main/java/com/deal4u/fourplease/domain/auction/entity/AuctionStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/entity/AuctionStatus.java
@@ -1,5 +1,12 @@
 package com.deal4u.fourplease.domain.auction.entity;
 
 public enum AuctionStatus {
-    OPEN, CLOSED, FAIL
+    OPEN,            // 경매 진행 중
+    FAIL,            // 유찰
+    PENDING,         // 결제 대기
+    SUCCESS,         // 결제 완료
+    REJECTED,        // 차상위 대기
+    INTRANSIT,       // 배송 중
+    DELIVERED,       // 구매 확정
+    CLOSE,           // 경매 종료
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/entity/AuctionStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/entity/AuctionStatus.java
@@ -8,5 +8,5 @@ public enum AuctionStatus {
     REJECTED,        // 차상위 대기
     INTRANSIT,       // 배송 중
     DELIVERED,       // 구매 확정
-    CLOSE,           // 경매 종료
+    CLOSE           // 경매 종료
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/entity/SaleAuctionStatus.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/entity/SaleAuctionStatus.java
@@ -1,5 +1,0 @@
-package com.deal4u.fourplease.domain.auction.entity;
-
-public enum SaleAuctionStatus {
-    OPEN, PENDING, SUCCESS, REJECT, INTRANSIT, DELIVERED, FAIL
-}

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -39,7 +39,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "FROM Auction a "
             + "WHERE a.auctionId = :auctionId "
             + "AND a.deleted = false "
-            + "AND a.status = 'CLOSED'")
+            + "AND a.status = 'CLOSE'")
     Optional<Auction> findByAuctionIdAndDeletedFalseAndStatusClosed(
             @Param("auctionId") Long auctionId);
 

--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -45,14 +46,11 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
     @Query("SELECT a "
             + "FROM Auction a "
-            + "JOIN FETCH a.product p "
             + "WHERE a.deleted = false "
-            + "AND p.productId in :productIds "
+            + "AND a.product.seller.member.memberId = :sellerId "
             + "ORDER BY a.createdAt DESC")
-    Page<Auction> findAllByProductIdIn(
-            @Param("productIds") List<Long> productIds,
-            Pageable pageable
-    );
+    @EntityGraph(attributePaths = {"product"}) // 필요한 연관 엔티티 지연 로딩 없이 미리 로딩
+    Page<Auction> findAllBySellerId(@Param("sellerId") Long sellerId, Pageable pageable);
 
     @Query("SELECT a "
             + "FROM Auction a "

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -122,21 +122,20 @@ public class AuctionService {
                             .getBidSummaryDto(auction.getAuctionId());
                     return SellerSaleListResponse.toSellerSaleListResponse(
                             auction,
-                            bidSummaryDto,
-                            auctionSupportService.getSaleAuctionStatus(auction)
+                            bidSummaryDto
                     );
                 });
 
         return PageResponse.fromPage(sellerSaleListResponsePage);
     }
 
-    // TODO: auction 상태를 CLOSED로 변경하는 메서드로 대체 필요
+    // TODO: 추후 AuctionStatusService로 이동
     @Transactional
     public void close(Auction auction) {
         auction.close();
     }
 
-    // TODO: auction 상태를 FAIL로 변경하는 메서드로 대체 필요
+    // TODO: 추후 AuctionStatusService로 이동
     @Transactional
     public void fail(Auction auction) {
         auction.fail();

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -116,23 +116,10 @@ public class AuctionService {
             Long sellerId,
             Pageable pageable
     ) {
-        List<Product> products = productService.getProductListBySellerId(sellerId);
+        Page<Auction> auctionPage = auctionRepository.findAllBySellerId(sellerId, pageable);
 
-        List<Long> productIds = products.stream()
-                .map(Product::getProductId)
-                .toList();
-
-        Page<Auction> auctionPage = auctionRepository.findAllByProductIdIn(productIds, pageable);
-
-        Page<SellerSaleListResponse> sellerSaleListResponsePage = auctionPage
-                .map(auction -> {
-                    BidSummaryDto bidSummaryDto = bidService
-                            .getBidSummaryDto(auction.getAuctionId());
-                    return SellerSaleListResponse.toSellerSaleListResponse(
-                            auction,
-                            bidSummaryDto
-                    );
-                });
+        Page<SellerSaleListResponse> sellerSaleListResponsePage =
+                auctionSupportService.getSellerSaleListResponses(auctionPage);
 
         return PageResponse.fromPage(sellerSaleListResponsePage);
     }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -1,6 +1,8 @@
 package com.deal4u.fourplease.domain.auction.service;
 
+import static com.deal4u.fourplease.domain.auction.validator.Validator.validateAuctionStatus;
 import static com.deal4u.fourplease.domain.auction.validator.Validator.validateSeller;
+import static com.deal4u.fourplease.global.exception.ErrorCode.AUCTION_CAN_NOT_DELETE;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
@@ -10,6 +12,7 @@ import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.service.BidService;
@@ -74,7 +77,9 @@ public class AuctionService {
         Auction targetAuction = auctionRepository.findByIdWithProduct(auctionId)
                 .orElseThrow(ErrorCode.AUCTION_NOT_FOUND::toException);
 
-        // TODO: Auction status 업데이트 후 낙찰된 경매는 취소 불가 기능 추가
+        // Auction status 업데이트 후 낙찰된 경매는 취소 불가 기능 추가
+        String status = targetAuction.getStatus().toString();
+        validateAuctionStatus(status);
 
         // Seller가 member와 일치하지 않으면 403 예외 발생
         validateSeller(targetAuction.getProduct().getSeller(), member);

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -11,7 +11,6 @@ import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.Product;
-import com.deal4u.fourplease.domain.auction.reader.AuctionReader;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -164,7 +164,7 @@ public class AuctionService {
         averageRating = averageRating != null ? averageRating : 0.0;
 
         Integer completedDeals =
-                auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED);
+                auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE);
 
         return new SellerInfoResponse(
                 sellerId,

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -87,7 +87,7 @@ public class AuctionService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponse<AuctionListResponse> findAll(AuctionSearchRequest request) {
+    public PageResponse<AuctionListResponse> findAll(AuctionSearchRequest request, Member member) {
         Page<Auction> auctionPage = getAuctionPage(
                 request.page(),
                 request.size(),
@@ -97,7 +97,7 @@ public class AuctionService {
         );
 
         Page<AuctionListResponse> auctionListResponsePage =
-                auctionSupportService.getAuctionListResponses(auctionPage);
+                auctionSupportService.getAuctionListResponses(auctionPage, member);
 
         return PageResponse.fromPage(auctionListResponsePage);
     }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -5,7 +5,6 @@ import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.wishlist.service.WishlistService;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -2,6 +2,7 @@ package com.deal4u.fourplease.domain.auction.service;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
+import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.member.entity.Member;
@@ -26,10 +27,9 @@ public class AuctionSupportService {
             Page<Auction> auctionPage,
             Member member
     ) {
-        List<Long> auctionIds = new ArrayList<>();
-        auctionPage.getContent().forEach(auction -> {
-            auctionIds.add(auction.getAuctionId());
-        });
+        List<Long> auctionIds = auctionPage.getContent().stream()
+                .map(Auction::getAuctionId)
+                .toList();
 
         // IN 쿼리로 한번에 가져오기
         Map<Long, BidSummaryDto> bidSummaryDtoMap = bidService.getBidSummaryDtoMap(auctionIds);
@@ -41,6 +41,19 @@ public class AuctionSupportService {
                     bidSummaryDto,
                     wishlistService.isWishlist(auction, member.getMemberId())
             );
+        });
+    }
+
+    public Page<SellerSaleListResponse> getSellerSaleListResponses(Page<Auction> auctionPage) {
+        List<Long> auctionIds = auctionPage.getContent().stream()
+                .map(Auction::getAuctionId)
+                .toList();
+
+        Map<Long, BidSummaryDto> bidSummaryDtoMap = bidService.getBidSummaryDtoMap(auctionIds);
+
+        return auctionPage.map(auction -> {
+            BidSummaryDto bidSummaryDto = bidSummaryDtoMap.get(auction.getAuctionId());
+            return SellerSaleListResponse.toSellerSaleListResponse(auction, bidSummaryDto);
         });
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -5,6 +5,10 @@ import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.wishlist.service.WishlistService;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -19,15 +23,21 @@ public class AuctionSupportService {
     private final WishlistService wishlistService;
 
     public Page<AuctionListResponse> getAuctionListResponses(Page<Auction> auctionPage) {
-        return auctionPage
-                .map(auction -> {
-                    BidSummaryDto bidSummaryDto = bidService
-                            .getBidSummaryDto(auction.getAuctionId());
-                    return AuctionListResponse.toAuctionListResponse(
-                            auction,
-                            bidSummaryDto,
-                            wishlistService.isWishlist(auction)
-                    );
-                });
+        List<Long> auctionIds = new ArrayList<>();
+        auctionPage.getContent().forEach(auction -> {
+            auctionIds.add(auction.getAuctionId());
+        });
+
+        // IN 쿼리로 한번에 가져오기
+        Map<Long, BidSummaryDto> bidSummaryDtoMap = bidService.getBidSummaryDtoMap(auctionIds);
+
+        return auctionPage.map(auction -> {
+            BidSummaryDto bidSummaryDto = bidSummaryDtoMap.get(auction.getAuctionId());
+            return AuctionListResponse.toAuctionListResponse(
+                    auction,
+                    bidSummaryDto,
+                    wishlistService.isWishlist(auction)
+            );
+        });
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -7,9 +7,9 @@ import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.wishlist.service.WishlistService;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -34,12 +34,17 @@ public class AuctionSupportService {
         // IN 쿼리로 한번에 가져오기
         Map<Long, BidSummaryDto> bidSummaryDtoMap = bidService.getBidSummaryDtoMap(auctionIds);
 
+        Set<Long> wishlistAuctionIds =
+                wishlistService.getWishlistAuctionIds(auctionIds, member.getMemberId());
+
         return auctionPage.map(auction -> {
             BidSummaryDto bidSummaryDto = bidSummaryDtoMap.get(auction.getAuctionId());
+            boolean isWishlist = wishlistAuctionIds.contains(auction.getAuctionId());
+
             return AuctionListResponse.toAuctionListResponse(
                     auction,
                     bidSummaryDto,
-                    wishlistService.isWishlist(auction, member.getMemberId())
+                    isWishlist
             );
         });
     }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -3,13 +3,8 @@ package com.deal4u.fourplease.domain.auction.service;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
-import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
-import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
 import com.deal4u.fourplease.domain.bid.service.BidService;
-import com.deal4u.fourplease.domain.settlement.repository.SettlementRepository;
-import com.deal4u.fourplease.domain.shipment.repository.ShipmentRepository;
 import com.deal4u.fourplease.domain.wishlist.service.WishlistService;
-import com.deal4u.fourplease.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -23,9 +18,6 @@ public class AuctionSupportService {
     private final BidService bidService;
     private final WishlistService wishlistService;
 
-    private final SettlementRepository settlementRepository;
-    private final ShipmentRepository shipmentRepository;
-
     public Page<AuctionListResponse> getAuctionListResponses(Page<Auction> auctionPage) {
         return auctionPage
                 .map(auction -> {
@@ -37,45 +29,5 @@ public class AuctionSupportService {
                             wishlistService.isWishlist(auction)
                     );
                 });
-    }
-
-    // TODO: 추후 개선 필요
-    public SaleAuctionStatus getSaleAuctionStatus(Auction auction) {
-        if (auction.getStatus().equals(AuctionStatus.OPEN)) {
-            return SaleAuctionStatus.OPEN;
-        }
-        if (auction.getStatus().equals(AuctionStatus.FAIL)) {
-            return SaleAuctionStatus.FAIL;
-        }
-        // AuctionStatus.CLOSE
-        return getSettlementStatus(auction.getAuctionId());
-    }
-
-    private SaleAuctionStatus getSettlementStatus(Long auctionId) {
-        String settlementStatus = settlementRepository.getSettlementStatusByAuctionId(auctionId)
-                .toString();
-        if (settlementStatus.equals("PENDING")) {
-            return SaleAuctionStatus.PENDING;
-        }
-        if (settlementStatus.equals("SUCCESS")) {
-            return SaleAuctionStatus.SUCCESS;
-        }
-        if (settlementStatus.equals("REJECTED")) {
-            return SaleAuctionStatus.REJECT;
-        }
-
-        return getShipmentStatus(auctionId);
-    }
-
-    private SaleAuctionStatus getShipmentStatus(Long auctionId) {
-        String shipmentStatus = shipmentRepository.getShipmentStatusByAuctionId(auctionId)
-                .toString();
-        if (shipmentStatus.equals("INTRANSIT")) {
-            return SaleAuctionStatus.INTRANSIT;
-        }
-        if (shipmentStatus.equals("DELIVERED")) {
-            return SaleAuctionStatus.DELIVERED;
-        }
-        throw ErrorCode.STATUS_NOT_FOUND.toException();
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionSupportService.java
@@ -4,6 +4,7 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.bid.service.BidService;
+import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.wishlist.service.WishlistService;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +22,10 @@ public class AuctionSupportService {
     private final BidService bidService;
     private final WishlistService wishlistService;
 
-    public Page<AuctionListResponse> getAuctionListResponses(Page<Auction> auctionPage) {
+    public Page<AuctionListResponse> getAuctionListResponses(
+            Page<Auction> auctionPage,
+            Member member
+    ) {
         List<Long> auctionIds = new ArrayList<>();
         auctionPage.getContent().forEach(auction -> {
             auctionIds.add(auction.getAuctionId());
@@ -35,7 +39,7 @@ public class AuctionSupportService {
             return AuctionListResponse.toAuctionListResponse(
                     auction,
                     bidSummaryDto,
-                    wishlistService.isWishlist(auction)
+                    wishlistService.isWishlist(auction, member.getMemberId())
             );
         });
     }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/validator/Validator.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/validator/Validator.java
@@ -1,5 +1,7 @@
 package com.deal4u.fourplease.domain.auction.validator;
 
+import static com.deal4u.fourplease.global.exception.ErrorCode.AUCTION_CAN_NOT_DELETE;
+
 import com.deal4u.fourplease.domain.auction.entity.Seller;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.global.exception.ErrorCode;
@@ -18,6 +20,15 @@ public class Validator {
     public static void validateSeller(Seller seller, Member member) {
         if (!seller.getMember().equals(member)) {
             throw ErrorCode.FORBIDDEN_RECEIVER.toException();
+        }
+    }
+
+    // 경매 삭제가 가능한 경매 상태인지 확인하는 메서드
+    public static void validateAuctionStatus(String auctionStatus) {
+        List<String> undeletableStatuses =
+                List.of("PENDING", "SUCCESS", "REJECTED", "INTRANSIT", "DELIVERED");
+        if (undeletableStatuses.contains(auctionStatus)) {
+            throw AUCTION_CAN_NOT_DELETE.toException();
         }
     }
 

--- a/src/main/java/com/deal4u/fourplease/domain/auth/service/CustomOauth2UserService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auth/service/CustomOauth2UserService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
     private final MemberRepository memberRepository;
 
     @Override

--- a/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
@@ -19,8 +19,13 @@ import com.deal4u.fourplease.global.exception.ErrorCode;
 import com.deal4u.fourplease.global.lock.NamedLock;
 import com.deal4u.fourplease.global.lock.NamedLockProvider;
 import java.math.BigDecimal;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -160,4 +165,19 @@ public class BidService {
         return Bidder.createBidder(member);
     }
 
+    public Map<Long, BidSummaryDto> getBidSummaryDtoMap(List<Long> auctionIds) {
+        Map<Long, List<BigDecimal>> auctionBidPricesMap =
+                bidRepository.findPricesByAuctionIdsGrouped(auctionIds);
+
+        Map<Long, BidSummaryDto> bidSummaryDtoMap = new HashMap<>();
+        for (Map.Entry<Long, List<BigDecimal>> entry : auctionBidPricesMap.entrySet()) {
+            Long auctionId = entry.getKey();
+            List<BigDecimal> bidPrices = entry.getValue();
+
+            BidSummaryDto bidSummaryDto = BidSummaryDto.toBidSummaryDto(bidPrices);
+            bidSummaryDtoMap.put(auctionId, bidSummaryDto);
+        }
+
+        return bidSummaryDtoMap;
+    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
@@ -166,9 +166,11 @@ public class BidService {
     }
 
     public Map<Long, BidSummaryDto> getBidSummaryDtoMap(List<Long> auctionIds) {
+        // IN으로 한번에 가져오기
         Map<Long, List<BigDecimal>> auctionBidPricesMap =
                 bidRepository.findPricesByAuctionIdsGrouped(auctionIds);
 
+        // BudSummaryDto로 변환
         Map<Long, BidSummaryDto> bidSummaryDtoMap = new HashMap<>();
         for (Map.Entry<Long, List<BigDecimal>> entry : auctionBidPricesMap.entrySet()) {
             Long auctionId = entry.getKey();

--- a/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/bid/service/BidService.java
@@ -168,7 +168,7 @@ public class BidService {
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     public Map<Long, BidSummaryDto> getBidSummaryDtoMap(List<Long> auctionIds) {
         // 개수가 많은 경우를 대비하여 batch 처리
-        final int BATCH_SIZE = 500;
+        final int BATCH_SIZE = 1000;
         Map<Long, BidSummaryDto> bidSummaryDtoMap = new HashMap<>();
 
         for (int i = 0; i < auctionIds.size(); i += BATCH_SIZE) {

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
@@ -16,5 +16,13 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
             + "AND w.memberId = :memberId")
     Page<Wishlist> findAll(Pageable pageable, @Param("memberId") Long memberId);
 
-    boolean existsByAuctionAndDeletedFalse(Auction auction);
+    @Query("SELECT COUNT(w) > 0 "
+            + "FROM Wishlist w "
+            + "WHERE w.auction = :auction "
+            + "AND w.memberId = :memberId "
+            + "AND w.deleted = false")
+    boolean existsByAuctionAndMemberIdAndDeletedFalse(
+            @Param("auction") Auction auction,
+            @Param("memberId") Long memberId
+    );
 }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
@@ -3,7 +3,6 @@ package com.deal4u.fourplease.domain.wishlist.repository;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
 import java.util.Optional;
-import javax.swing.text.html.Option;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/repository/WishlistRepository.java
@@ -2,6 +2,7 @@ package com.deal4u.fourplease.domain.wishlist.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,14 +18,13 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
             + "AND w.memberId = :memberId")
     Page<Wishlist> findAll(Pageable pageable, @Param("memberId") Long memberId);
 
-
-    @Query("SELECT COUNT(w) > 0 "
+    @Query("SELECT w.auction.auctionId "
             + "FROM Wishlist w "
-            + "WHERE w.auction = :auction "
+            + "WHERE w.auction.auctionId IN :auctionIds "
             + "AND w.memberId = :memberId "
             + "AND w.deleted = false")
-    boolean existsByAuctionAndMemberIdAndDeletedFalse(
-            @Param("auction") Auction auction,
+    List<Long> findAuctionIdsInWishlist(
+            @Param("auctionIds") List<Long> auctionIds,
             @Param("memberId") Long memberId
     );
 

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -73,8 +73,7 @@ public class WishlistService {
                 });
     }
 
-    // TODO: 멤버 일치 여부 확인 필요
-    public boolean isWishlist(Auction auction) {
-        return wishlistRepository.existsByAuctionAndDeletedFalse(auction);
+    public boolean isWishlist(Auction auction, Long memberId) {
+        return wishlistRepository.existsByAuctionAndMemberIdAndDeletedFalse(auction, memberId);
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -61,6 +61,7 @@ public class WishlistService {
         return PageResponse.fromPage(wishlistResponsePage);
     }
 
+    // TODO: 멤버 일치 여부 확인 필요
     public boolean isWishlist(Auction auction) {
         return wishlistRepository.existsByAuctionAndDeletedFalse(auction);
     }

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -13,6 +13,9 @@ import com.deal4u.fourplease.domain.wishlist.dto.WishlistResponse;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
 import com.deal4u.fourplease.domain.wishlist.repository.WishlistRepository;
 import com.deal4u.fourplease.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -49,16 +52,25 @@ public class WishlistService {
     public PageResponse<WishlistResponse> findAll(Pageable pageable, Member member) {
         Page<Wishlist> wishlistPage = wishlistRepository.findAll(pageable, member.getMemberId());
 
-        Page<WishlistResponse> wishlistResponsePage = wishlistPage
-                .map(wishlist -> {
-                    BidSummaryDto bidSummaryDto =
-                            bidService.getBidSummaryDto(
-                                    wishlist.getAuction().getAuctionId()
-                            );
-                    return WishlistResponse.toWishlistResponse(wishlist, bidSummaryDto);
-                });
+        Page<WishlistResponse> wishlistResponsePage = getWishlistResponses(wishlistPage);
 
         return PageResponse.fromPage(wishlistResponsePage);
+    }
+
+    private Page<WishlistResponse> getWishlistResponses(Page<Wishlist> wishlistPage) {
+        List<Long> auctionIds = new ArrayList<>();
+        wishlistPage.getContent().forEach(wishlist -> {
+            Long auctionId = wishlist.getAuction().getAuctionId();
+            auctionIds.add(auctionId);
+        });
+
+        Map<Long, BidSummaryDto> bidSummaryDtoMap = bidService.getBidSummaryDtoMap(auctionIds);
+        return wishlistPage
+                .map(wishlist -> {
+                    BidSummaryDto bidSummaryDto =
+                            bidSummaryDtoMap.get(wishlist.getAuction().getAuctionId());
+                    return WishlistResponse.toWishlistResponse(wishlist, bidSummaryDto);
+                });
     }
 
     // TODO: 멤버 일치 여부 확인 필요

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/service/WishlistService.java
@@ -14,8 +14,10 @@ import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
 import com.deal4u.fourplease.domain.wishlist.repository.WishlistRepository;
 import com.deal4u.fourplease.global.exception.ErrorCode;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -76,7 +78,19 @@ public class WishlistService {
                 });
     }
 
-    public boolean isWishlist(Auction auction, Long memberId) {
-        return wishlistRepository.existsByAuctionAndMemberIdAndDeletedFalse(auction, memberId);
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    public Set<Long> getWishlistAuctionIds(List<Long> auctionIds, Long memberId) {
+        final int BATCH_SIZE = 1000;
+        Set<Long> wishlistAuctionIds = new HashSet<>();
+
+        for (int i = 0; i < auctionIds.size(); i += BATCH_SIZE) {
+            int min = Math.min(i + BATCH_SIZE, auctionIds.size());
+            List<Long> batch = auctionIds.subList(i, min);
+
+            wishlistAuctionIds.addAll(
+                    wishlistRepository.findAuctionIdsInWishlist(batch, memberId)
+            );
+        }
+        return wishlistAuctionIds;
     }
 }

--- a/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
+++ b/src/main/java/com/deal4u/fourplease/global/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
     PAYMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리된 결제입니다"),
     SETTLEMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 차상위 입찰자에 대한 정산이 존재합니다."),
     AUCTION_SCHEDULE_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 경매의 마감 스케쥴이 이미 등록되어 있습니다."),
+    AUCTION_CAN_NOT_DELETE(HttpStatus.CONFLICT, "낙찰된 경매는 삭제할 수 없습니다."),
 
     // 422 - Unprocessable Entity,
     NICKNAME_ALREADY_EXISTS(HttpStatus.UNPROCESSABLE_ENTITY, "이미 존재하는 닉네임입니다."),

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -204,10 +205,11 @@ class AuctionControllerTests extends BaseTokenTest {
 
         PageResponse<AuctionListResponse> resp = genAuctionListResponsePageResponse();
 
-        when(auctionService.findAll(req)).thenReturn(resp);
+        when(auctionService.findAll(eq(req), any(Member.class))).thenReturn(resp);
 
         mockMvc.perform(
                         get("/api/v1/auctions")
+                                .with(user("user").roles("USER")) // 인증 정보 주입
                                 .param("page", "0")
                                 .param("size", "20")
                                 .param("keyword", req.keyword())
@@ -225,6 +227,5 @@ class AuctionControllerTests extends BaseTokenTest {
                 .andExpect(jsonPath("$.page").value(resp.getPage()))
                 .andExpect(jsonPath("$.size").value(resp.getSize()))
                 .andDo(print());
-
     }
 }

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -271,6 +271,8 @@ class AuctionServiceTests {
     @DisplayName("전체 경매 목록에서 검색어로 필터랑하고 최신순으로 정렬한다")
     void findAllShouldFillerByKeywordAndOrderByLatest() {
 
+        Member member = genMember();
+
         AuctionSearchRequest req = new AuctionSearchRequest(
                 0,
                 20,
@@ -307,11 +309,11 @@ class AuctionServiceTests {
         );
 
         when(auctionRepository.findByKeyword(req.keyword(), pageable)).thenReturn(auctionPage);
-        when(auctionSupportService.getAuctionListResponses(auctionPage))
+        when(auctionSupportService.getAuctionListResponses(auctionPage, member))
                 .thenReturn(auctionListResponsePage);
 
         PageResponse<AuctionListResponse> resp =
-                auctionService.findAll(req);
+                auctionService.findAll(req, member);
 
         assertThat(resp.getContent().getFirst().name()).isEqualTo("축구공");
         assertThat(resp.getTotalElements()).isEqualTo(auctionListResponseList.size());
@@ -321,6 +323,8 @@ class AuctionServiceTests {
     @Test
     @DisplayName("전체 경매 목록에서 카테고리로 필터링하고 입찰순으로 필터링한다")
     void findAllShouldFilterByCategoryAndOrderByBidCount() {
+
+        Member member = genMember();
 
         AuctionSearchRequest req = new AuctionSearchRequest(
                 0,
@@ -365,10 +369,10 @@ class AuctionServiceTests {
 
         when(auctionRepository.findByCategoryIdOrderByBidCount(req.categoryId(), pageable))
                 .thenReturn(auctionPage);
-        when(auctionSupportService.getAuctionListResponses(auctionPage))
+        when(auctionSupportService.getAuctionListResponses(auctionPage, member))
                 .thenReturn(auctionListResponsePage);
 
-        PageResponse<AuctionListResponse> resp = auctionService.findAll(req);
+        PageResponse<AuctionListResponse> resp = auctionService.findAll(req, member);
 
         assertThat(resp.getContent().getFirst().bidCount()).isEqualTo(40);
         assertThat(resp.getContent().getLast().bidCount()).isEqualTo(20);

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -25,7 +25,6 @@ import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.Product;
-import com.deal4u.fourplease.domain.auction.entity.SaleAuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.Seller;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
 import com.deal4u.fourplease.domain.bid.service.BidService;
@@ -246,8 +245,6 @@ class AuctionServiceTests {
                         return new BidSummaryDto(BigDecimal.ZERO, 0);
                     }
                 });
-        when(auctionSupportService.getSaleAuctionStatus(any(Auction.class)))
-                .thenReturn(SaleAuctionStatus.OPEN);
 
         PageResponse<SellerSaleListResponse> resp =
                 auctionService.findSalesBySellerId(sellerId, pageable);
@@ -268,20 +265,6 @@ class AuctionServiceTests {
         assertThat(resp.getTotalPages()).isEqualTo(1);
         assertThat(resp.getPage()).isZero();
         assertThat(resp.getSize()).isEqualTo(20);
-    }
-
-    @Test
-    @DisplayName("Auction의 상태를 OPEN에서 CLOSE로 변환한다")
-    void closeShouldChangeAuctionStatusOpenIntoClose() {
-
-        Auction auction = genAuctionCreateRequest().toEntity(genProduct());
-
-        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.OPEN);
-
-        auctionService.close(auction);
-        
-        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.CLOSED);
-
     }
 
     @Test

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -425,7 +425,7 @@ class AuctionServiceTests {
         when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
         when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(
                 averageRating);
-        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED))
+        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE))
                 .thenReturn(completedDeals);
 
         // When

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -477,7 +477,7 @@ class AuctionServiceTests {
                 Optional.of(auction));
         when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
         when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(averageRating);
-        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED))
+        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE))
                 .thenReturn(completedDeals);
 
         // When
@@ -530,7 +530,7 @@ class AuctionServiceTests {
                 Optional.of(auction));
         when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
         when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(averageRating);
-        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSED))
+        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE))
                 .thenReturn(completedDeals);
 
         // When

--- a/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/util/TestUtils.java
@@ -9,6 +9,7 @@ import com.deal4u.fourplease.domain.auction.dto.SellerSaleListResponse;
 import com.deal4u.fourplease.domain.auction.entity.Address;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
 import com.deal4u.fourplease.domain.auction.entity.AuctionDuration;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.BidPeriod;
 import com.deal4u.fourplease.domain.auction.entity.Category;
 import com.deal4u.fourplease.domain.auction.entity.Product;
@@ -184,6 +185,7 @@ public class TestUtils {
                         .instantBidPrice(BigDecimal.valueOf(250000))
                         .duration(new AuctionDuration(LocalDateTime.now(),
                                 LocalDateTime.now().plusDays(3)))
+                        .status(AuctionStatus.OPEN)
                         .build(),
                 Auction.builder()
                         .auctionId(2L)
@@ -206,6 +208,7 @@ public class TestUtils {
                         .instantBidPrice(null)
                         .duration(new AuctionDuration(LocalDateTime.now(),
                                 LocalDateTime.now().plusDays(7)))
+                        .status(AuctionStatus.OPEN)
                         .build(),
                 Auction.builder()
                         .auctionId(3L)
@@ -228,6 +231,7 @@ public class TestUtils {
                         .instantBidPrice(null)
                         .duration(new AuctionDuration(LocalDateTime.now(),
                                 LocalDateTime.now().plusDays(1)))
+                        .status(AuctionStatus.OPEN)
                         .build()
 
         );

--- a/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/order/service/OrderServiceTest.java
@@ -84,7 +84,7 @@ class OrderServiceTest {
                 .auctionId(2L)
                 .startingPrice(new BigDecimal("100"))
                 .instantBidPrice(new BigDecimal("20000"))
-                .status(AuctionStatus.CLOSED)
+                .status(AuctionStatus.CLOSE)
                 .deleted(false)
                 .build();
 

--- a/src/test/java/com/deal4u/fourplease/domain/review/service/ReviewServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/review/service/ReviewServiceTests.java
@@ -108,7 +108,7 @@ class ReviewServiceTests {
                 .product(product)
                 .startingPrice(new BigDecimal("100"))
                 .instantBidPrice(new BigDecimal("20000"))
-                .status(AuctionStatus.CLOSED)
+                .status(AuctionStatus.CLOSE)
                 .deleted(false)
                 .build();
 

--- a/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/wishlist/service/WishlistServiceTests.java
@@ -6,6 +6,7 @@ import static com.deal4u.fourplease.domain.auction.util.TestUtils.genWishlist;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.deal4u.fourplease.domain.auction.dto.BidSummaryDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.service.AuctionReaderImpl;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.auction.service.AuctionSupportService;
@@ -26,7 +28,9 @@ import com.deal4u.fourplease.domain.wishlist.dto.WishlistResponse;
 import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
 import com.deal4u.fourplease.domain.wishlist.repository.WishlistRepository;
 import com.deal4u.fourplease.global.exception.GlobalException;
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -132,27 +136,73 @@ class WishlistServiceTests {
     void findAllShouldReturnWishlistPageResponse() {
 
         Member member = mock(Member.class);
-        Auction auction = genAuction();
-        Wishlist wishlist = Wishlist.builder()
+        Pageable pageable = PageRequest.of(0, 20);
+
+        Auction auction1 = Auction.builder()
+                .auctionId(1L)
+                .product(Product.builder()
+                        .name("목도리")
+                        .thumbnailUrl("http://example.com/thumbnail1.jpg")
+                        .build()
+                )
+                .startingPrice(BigDecimal.valueOf(1000000))
+                .build();
+
+        Auction auction2 = Auction.builder()
+                .auctionId(2L)
+                .product(Product.builder()
+                        .name("축구공")
+                        .thumbnailUrl("http://example.com/thumbnail2.jpg")
+                        .build()
+                )
+                .startingPrice(BigDecimal.valueOf(5000000))
+                .build();
+
+        Wishlist wishlist1 = Wishlist.builder()
+                .auction(auction1)
                 .memberId(1L)
-                .auction(auction)
                 .deleted(false)
                 .build();
-        BidSummaryDto bidSummaryDto = mock(BidSummaryDto.class);
 
-        Pageable pageable = PageRequest.of(0, 20);
-        Page<Wishlist> wishlistPage = new PageImpl<>(List.of(wishlist));
+        Wishlist wishlist2 = Wishlist.builder()
+                .auction(auction2)
+                .memberId(1L)
+                .deleted(false)
+                .build();
+
+        List<Wishlist> wishlistList = List.of(wishlist1, wishlist2);
+        Page<Wishlist> wishlistPage = new PageImpl<>(wishlistList, pageable, wishlistList.size());
+
+        Map<Long, BidSummaryDto> bidSummaryDtoMap = Map.of(
+                1L, new BidSummaryDto(BigDecimal.valueOf(2000000), 5),
+                2L, new BidSummaryDto(BigDecimal.valueOf(10000000), 20)
+        );
 
         when(member.getMemberId()).thenReturn(1L);
         when(wishlistRepository.findAll(pageable, 1L)).thenReturn(wishlistPage);
-        when(bidService.getBidSummaryDto(auction.getAuctionId()))
-                .thenReturn(bidSummaryDto);
+        when(bidService.getBidSummaryDtoMap(List.of(1L, 2L))).thenReturn(bidSummaryDtoMap);
 
-        PageResponse<WishlistResponse> resp = wishlistService.findAll(pageable, member);
+        PageResponse<WishlistResponse> response = wishlistService.findAll(pageable, member);
 
-        assertThat(resp.getContent()).hasSize(1);
-        assertThat(resp.getContent().getFirst().name()).isEqualTo("칫솔");
+        assertThat(response).isNotNull();
+        assertThat(response.getContent()).hasSize(2);
 
+        WishlistResponse first = response.getContent().get(0);
+        assertThat(first.name()).isEqualTo("목도리");
+        assertThat(first.thumbnailUrl()).isEqualTo("http://example.com/thumbnail1.jpg");
+        assertThat(first.maxPrice()).isEqualTo(BigDecimal.valueOf(2000000));
+        assertThat(first.bidCount()).isEqualTo(5);
+
+        WishlistResponse second = response.getContent().get(1);
+        assertThat(second.name()).isEqualTo("축구공");
+        assertThat(second.thumbnailUrl()).isEqualTo("http://example.com/thumbnail2.jpg");
+        assertThat(second.maxPrice()).isEqualTo(BigDecimal.valueOf(10000000));
+        assertThat(second.bidCount()).isEqualTo(20);
+
+        assertThat(response.getPage()).isZero();
+        assertThat(response.getSize()).isEqualTo(20);
+        assertThat(response.getTotalElements()).isEqualTo(2);
+        assertThat(response.getTotalPages()).isEqualTo(1);
     }
 
 }

--- a/src/test/java/com/deal4u/fourplease/global/scheduler/AuctionScheduleServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/global/scheduler/AuctionScheduleServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.deal4u.fourplease.domain.auction.dto.AuctionCreateRequest;
 import com.deal4u.fourplease.domain.auction.dto.ProductCreateDto;
 import com.deal4u.fourplease.domain.auction.entity.Auction;
+import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import com.deal4u.fourplease.domain.auction.entity.Product;
 import com.deal4u.fourplease.domain.auction.entity.Seller;
 import com.deal4u.fourplease.domain.auction.repository.AuctionRepository;
@@ -93,6 +94,7 @@ class AuctionScheduleServiceTest {
         Product product = genProduct();
         Seller seller = product.getSeller();
         Auction auction = Auction.builder()
+                .status(AuctionStatus.OPEN)
                 .auctionId(auctionId)
                 .product(product)
                 .build();

--- a/src/test/java/com/deal4u/fourplease/global/scheduler/SettlementScheduleServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/global/scheduler/SettlementScheduleServiceTest.java
@@ -75,7 +75,7 @@ class SettlementScheduleServiceTest {
                 .auctionId(auctionId)
                 .product(product)
                 .duration(new AuctionDuration(auctionStartTime, auctionEndTime))
-                .status(AuctionStatus.CLOSED)
+                .status(AuctionStatus.CLOSE)
                 .build();
 
         // Bid 생성
@@ -107,7 +107,7 @@ class SettlementScheduleServiceTest {
 
         // then
         // 1. 경매 종료
-        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.CLOSED);
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.CLOSE);
 
         // 2. 낙찰자 설정
         assertThat(bid.isSuccessfulBidder()).isTrue();


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #82 

## 📝 작업 내용
1. 목록 조회 쿼리 수정
- 이전: 경매/위시리스트 목록 조회 시 각 auction/wishlist 마다 bidRepository에서 필요한 bid 정보 호출
- 개선방안: 경매 ID들을 한 번에 IN 절로 조회 후, 메모리에서 매칭시키는 방식으로 수정

2. 경매 상태 조회 수정
- 이전: 각 엔티티에 분포되어 있는 status를 조회해 경매 상태를 저장
- 개선방안: 수정된 auction의 status(현재는 SaleAuctionStatus)를 조회해 경매 상태를 저장

3. 전체 경매 조회 시 인자에 멤버 추가
- 이전: 전체 경매 조회 시 멤버 정보가 없어 위시리스트 저장 정보를 불러올 수 없음
- 개선방안: 전체 경매 조회 시 멤버를 인자로 추가하여 위시리스트 정보 조회

4. 경매가 낙찰된 경우 삭제 불가능 하도록 수정
- 이전: 경매가 낙찰된 경우에도 삭제를 할 수 있는 문제 발생
- 개선방안: 경매 삭제를 시도할 경우 status를 확인하여 낙찰된 경우 예외를 던지도록 수정

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?