### PR TITLE
fix(87) : 다중 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -5,18 +5,17 @@ import com.deal4u.fourplease.domain.auction.dto.AuctionDetailResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionImageUrlResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionListResponse;
 import com.deal4u.fourplease.domain.auction.dto.AuctionSearchRequest;
-import com.deal4u.fourplease.domain.auction.dto.SellerInfoResponse;
 import com.deal4u.fourplease.domain.auction.service.AuctionService;
 import com.deal4u.fourplease.domain.auction.service.SaveAuctionImageService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
-import com.deal4u.fourplease.domain.member.repository.MemberRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
@@ -42,7 +41,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class AuctionController {
 
     private final AuctionService auctionService;
-    private final MemberRepository memberRepository;
     private final SaveAuctionImageService saveAuctionImageService;
 
     @Operation(summary = "전체 경매 조회")
@@ -98,17 +96,9 @@ public class AuctionController {
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/images")
     public AuctionImageUrlResponse readAuctionImageUrl(
-            @RequestParam(name = "image") MultipartFile image) {
-        return saveAuctionImageService.upload(memberRepository.findAll().getFirst(), image);
+            @RequestParam(name = "image") List<MultipartFile> image,
+            @AuthenticationPrincipal Member member) {
+        return saveAuctionImageService.upload(member, image);
     }
 
-    @Operation(summary = "특정 상품의 판매자 정보 조회")
-    @ApiResponse(responseCode = "200", description = "판매자 정보 반환 성공")
-    @ApiResponse(responseCode = "404", description = "경매나 판매자 정보를 찾을 수 없음")
-    @GetMapping("/{auctionId}/seller")
-    @ResponseStatus(HttpStatus.OK)
-    public SellerInfoResponse getSellerInfo(
-            @PathVariable(name = "auctionId") @Positive Long auctionId) {
-        return auctionService.getSellerInfo(auctionId);
-    }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionImageUrlResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionImageUrlResponse.java
@@ -1,5 +1,7 @@
 package com.deal4u.fourplease.domain.auction.dto;
 
-public record AuctionImageUrlResponse(String url) {
+import java.util.List;
+
+public record AuctionImageUrlResponse(List<String> imageUrls) {
 
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/mapper/AutionImageUrlMapper.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/mapper/AutionImageUrlMapper.java
@@ -1,13 +1,13 @@
 package com.deal4u.fourplease.domain.auction.mapper;
 
 import com.deal4u.fourplease.domain.auction.dto.AuctionImageUrlResponse;
-import java.net.URL;
+import java.util.List;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class AutionImageUrlMapper {
 
-    public static AuctionImageUrlResponse toImageUrlResponse(URL auctionImageUrl) {
-        return new AuctionImageUrlResponse(auctionImageUrl.toString());
+    public static AuctionImageUrlResponse toImageUrlResponse(List<String> urls) {
+        return new AuctionImageUrlResponse(urls);
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/rules/DateTimeAuctionImageNameRule.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/rules/DateTimeAuctionImageNameRule.java
@@ -1,6 +1,7 @@
 package com.deal4u.fourplease.domain.auction.rules;
 
 import com.deal4u.fourplease.domain.auction.service.AuctionImageNameRule;
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Component;
@@ -10,9 +11,11 @@ public class DateTimeAuctionImageNameRule implements AuctionImageNameRule {
 
     private static final DateTimeFormatter formatter =
             DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss");
+    private static final SecureRandom random = new SecureRandom();
 
     @Override
     public String createAuctionPath() {
-        return formatter.format(LocalDateTime.now());
+        String format = formatter.format(LocalDateTime.now());
+        return format + random.nextInt();
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/SaveAuctionImageService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/SaveAuctionImageService.java
@@ -12,6 +12,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -34,13 +36,17 @@ public class SaveAuctionImageService {
         this.hostUrl = hostUrl;
     }
 
-    public AuctionImageUrlResponse upload(Member member, MultipartFile file) {
-        ImageType imageType = ImageType.findTypeByStr(file.getOriginalFilename()).orElseThrow(
-                ErrorCode.INVALID_IMAGE_TYPE::toException);
-        SavePath savePath = auctionSaveDataFactory.create(member.getNickName(), imageType);
-        URL url = fileSaver.save(savePath, file);
+    public AuctionImageUrlResponse upload(Member member, List<MultipartFile> files) {
+        List<String> urls = new ArrayList<>();
+        for (MultipartFile file : files) {
+            ImageType imageType = ImageType.findTypeByStr(file.getOriginalFilename()).orElseThrow(
+                    ErrorCode.INVALID_IMAGE_TYPE::toException);
+            SavePath savePath = auctionSaveDataFactory.create(member.getNickName(), imageType);
+            URL url = fileSaver.save(savePath, file);
+            urls.add(changeHostUrl(url).toString());
+        }
 
-        return AutionImageUrlMapper.toImageUrlResponse(changeHostUrl(url));
+        return AutionImageUrlMapper.toImageUrlResponse(urls);
     }
 
     private URL changeHostUrl(URL url) {

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -3,7 +3,6 @@ package com.deal4u.fourplease.domain.auction.controller;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionCreateRequest;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionDetailResponse;
 import static com.deal4u.fourplease.domain.auction.util.TestUtils.genAuctionListResponsePageResponse;
-import static com.deal4u.fourplease.domain.auction.util.TestUtils.genMember;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -64,9 +63,11 @@ class AuctionControllerTests extends BaseTokenTest {
     @MockitoBean
     private SaveAuctionImageService saveAuctionImageService;
 
+    private Member member;
+
     @BeforeEach
     void setUp() {
-        Member member = Member.builder()
+        member = Member.builder()
                 .memberId(1L)
                 .email("test@nave.com")
                 .role(Role.USER)
@@ -134,11 +135,8 @@ class AuctionControllerTests extends BaseTokenTest {
                 new byte[]{1, 2, 3, 4}
         );
 
-        Member member = Mockito.mock(Member.class);
-        when(member.getNickName()).thenReturn("test");
-        when(memberRepository.findAll()).thenReturn(List.of(member));
-        when(saveAuctionImageService.upload(member, file)).thenReturn(
-                new AuctionImageUrlResponse("test.com")
+        when(saveAuctionImageService.upload(member, List.of(file))).thenReturn(
+                new AuctionImageUrlResponse(List.of("test.com"))
         );
 
         mockMvc.perform(multipart("/api/v1/auctions/images").file(file)
@@ -156,10 +154,7 @@ class AuctionControllerTests extends BaseTokenTest {
                 new byte[]{1, 2, 3, 4}
         );
 
-        Member member = Mockito.mock(Member.class);
-        when(member.getNickName()).thenReturn("test");
-        when(memberRepository.findAll()).thenReturn(List.of(member));
-        when(saveAuctionImageService.upload(member, file)).thenThrow(
+        when(saveAuctionImageService.upload(member, List.of(file))).thenThrow(
                 ErrorCode.INVALID_IMAGE_TYPE.toException()
         );
 
@@ -178,10 +173,7 @@ class AuctionControllerTests extends BaseTokenTest {
                 new byte[]{1, 2, 3, 4}
         );
 
-        Member member = Mockito.mock(Member.class);
-        when(member.getNickName()).thenReturn("test");
-        when(memberRepository.findAll()).thenReturn(List.of(member));
-        when(saveAuctionImageService.upload(member, file)).thenThrow(
+        when(saveAuctionImageService.upload(member, List.of(file))).thenThrow(
                 ErrorCode.INVALID_FILE.toException()
         );
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/SaveAuctionImageServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/SaveAuctionImageServiceTest.java
@@ -13,6 +13,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 import lombok.Getter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,16 +39,16 @@ class SaveAuctionImageServiceTest {
                 "file",
                 "file.png",
                 "image/png", // valid MIME type and extension
-                new byte[] {1, 2}
+                new byte[]{1, 2}
         );
         Member test = Member.builder().nickName("test").build();
 
-        AuctionImageUrlResponse upload = saveAuctionImageService.upload(test, file);
+        AuctionImageUrlResponse upload = saveAuctionImageService.upload(test, List.of(file));
 
         assertThat(new SavePath(path, fileName + ".png")).isEqualTo(
                 fakeFileSaver.getInputSavePath());
         assertThat(file).isEqualTo(fakeFileSaver.getFile());
-        assertThat(upload.url()).isEqualTo("https://test.com" + path);
+        assertThat(upload.imageUrls().getFirst()).isEqualTo("https://test.com" + path);
     }
 
     @Test
@@ -62,11 +63,11 @@ class SaveAuctionImageServiceTest {
                 "file",
                 "file.txt",
                 "text/plain", // valid MIME type and extension
-                new byte[] {1, 2}
+                new byte[]{1, 2}
         );
         Member test = Member.builder().nickName("test").build();
 
-        assertThatThrownBy(() -> saveAuctionImageService.upload(test, file))
+        assertThatThrownBy(() -> saveAuctionImageService.upload(test, List.of(file)))
                 .isInstanceOf(GlobalException.class);
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #이슈 번호
- ex) #87 

## 📝 작업 내용
- 다중이미지 업로드 기능 구현

## ✅ 피드백 반영사항
- 단일 이미지 업로드만 가능하다가 다중이미지 업로드가 가능하게 수정

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트를 수행함
