### PR TITLE
feat(94) : 상품 상세에 isWishList 항목 추가

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/controller/AuctionController.java
@@ -75,8 +75,9 @@ public class AuctionController {
     @GetMapping("/{auctionId}/description")
     @ResponseStatus(HttpStatus.OK)
     public AuctionDetailResponse readAuction(
-            @PathVariable(name = "auctionId") @Positive Long auctionId) {
-        return auctionService.getByAuctionId(auctionId);
+            @PathVariable(name = "auctionId") @Positive Long auctionId,
+            @AuthenticationPrincipal Member member) {
+        return auctionService.getByAuctionId(auctionId, member);
     }
 
     @Operation(summary = "경매제거")

--- a/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionDetailResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/dto/AuctionDetailResponse.java
@@ -23,14 +23,17 @@ public record AuctionDetailResponse(
         LocalDateTime endTime,
 
         String thumbnailUrl,
-        List<String> imageUrls
+        List<String> imageUrls,
+
+        boolean isWishList
 
 ) {
 
     public static AuctionDetailResponse toAuctionDetailResponse(
             Auction auction,
             List<String> productImageUrls,
-            BidSummaryDto bidSummaryDto
+            BidSummaryDto bidSummaryDto,
+            boolean isWishList
     ) {
         Product product = auction.getProduct();
         return new AuctionDetailResponse(
@@ -44,7 +47,8 @@ public record AuctionDetailResponse(
                 product.getDescription(),
                 auction.getDuration().getEndTime(),
                 product.getThumbnailUrl(),
-                productImageUrls
+                productImageUrls,
+                isWishList
         );
     }
 

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -101,7 +101,7 @@ class AuctionControllerTests extends BaseTokenTest {
         Long auctionId = 1L;
         AuctionDetailResponse resp = genAuctionDetailResponse();
 
-        when(auctionService.getByAuctionId(auctionId)).thenReturn(resp);
+        when(auctionService.getByAuctionId(auctionId, null)).thenReturn(resp);
 
         mockMvc.perform(
                         get("/api/v1/auctions/{auctionId}/description", auctionId)

--- a/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/controller/AuctionControllerTests.java
@@ -101,13 +101,14 @@ class AuctionControllerTests extends BaseTokenTest {
         Long auctionId = 1L;
         AuctionDetailResponse resp = genAuctionDetailResponse();
 
-        when(auctionService.getByAuctionId(auctionId, null)).thenReturn(resp);
+        when(auctionService.getByAuctionId(eq(auctionId), any(Member.class))).thenReturn(resp);
 
         mockMvc.perform(
                         get("/api/v1/auctions/{auctionId}/description", auctionId)
                 ).andExpect(status().isOk())
                 .andExpect(jsonPath("$.productName").value(resp.productName()))
                 .andExpect(jsonPath("$.description").value(resp.description()))
+                .andExpect(jsonPath("$.isWishList").value(resp.isWishList()))
                 .andDo(print());
 
     }

--- a/src/test/java/com/deal4u/fourplease/testutil/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/testutil/TestUtils.java
@@ -116,7 +116,8 @@ public class TestUtils {
                 "한 번도 사용하지 않은 새 칫솔 입니다. 치약은 없습니다.",
                 LocalDateTime.now(),
                 "http://example.com/thumbnail.jpg",
-                List.of("http://example.com/image1.jpg", "http://example.com/image2.jpg")
+                List.of("http://example.com/image1.jpg", "http://example.com/image2.jpg"),
+                false
         );
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #94 

## 📝 작업 내용
- 상품 설명 조회 시에 로그인 / 비로그인을 기준으로 isWishList 항목 추가

```java
    @Operation(summary = "상품 설명")
    @ApiResponse(responseCode = "200", description = "상품 설명 반환")
    @ApiResponse(responseCode = "404", description = "상품을 찾을 수 없음")
    @GetMapping("/{auctionId}/description")
    @ResponseStatus(HttpStatus.OK)
    public AuctionDetailResponse readAuction(
            @PathVariable(name = "auctionId") @Positive Long auctionId,
            @AuthenticationPrincipal Member member) {
        return auctionService.getByAuctionId(auctionId, member);
    }
```

- 상기의 수정은 경우 securityConfig의 수정이 필요하기 때문에, 검토가 필요합니다.

현재는 `.requestMatchers(HttpMethod.GET).permitAll()` 로 인해서 허용이 되는 상태인 것을 확인하여서 따로 securityConfig의 수정은 하지 않았습니다.

로그인하지 않은 상태에서 받은 isWishList (false)입니다.
로그인 후에 true가 출력되는 부분은 postMan으로는 테스트하지 못했습니다.

```json
{
    "highestBidPrice": 200000.00,
    "instantBidPrice": 800000.00,
    "bidCount": 19,
    "startingPrice": 100000.00,
    "productName": "최신형 노트북",
    "categoryId": 1,
    "categoryName": "전자제품",
    "description": "한 번도 사용하지 않은 최신형 노트북입니다. 성능이 매우 뛰어납니다.",
    "endTime": "2025-08-04T21:59:06.407321",
    "thumbnailUrl": "https://example.com/images/laptop.jpg",
    "imageUrls": [],
    "isWishList": false
}
```

## ✅ 피드백 반영사항
- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제)

## 📸 스크린샷 (선택)

<img width="850" height="575" alt="image" src="https://github.com/user-attachments/assets/4b911197-d18b-4ba3-b76d-6d90eee730a3" />

<img width="853" height="298" alt="image" src="https://github.com/user-attachments/assets/e2253130-a8b2-4961-974e-5f2208e8c366" />

<img width="1281" height="914" alt="image" src="https://github.com/user-attachments/assets/75efce50-794a-46d9-840d-937e7884a3c2" />

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?