### PR TITLE
feat(97) : 마이페이지 내 정보 API 구현 및 테스트 작성

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -21,11 +21,9 @@ import com.deal4u.fourplease.domain.bid.service.BidService;
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
 import com.deal4u.fourplease.domain.review.repository.ReviewRepository;
-import com.deal4u.fourplease.domain.wishlist.entity.Wishlist;
 import com.deal4u.fourplease.domain.wishlist.repository.WishlistRepository;
 import com.deal4u.fourplease.global.scheduler.AuctionScheduleService;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -128,18 +126,6 @@ public class AuctionService {
                 auctionSupportService.getSellerSaleListResponses(auctionPage);
 
         return PageResponse.fromPage(sellerSaleListResponsePage);
-    }
-
-    // TODO: 추후 AuctionStatusService로 이동
-    @Transactional
-    public void close(Auction auction) {
-        auction.close();
-    }
-
-    // TODO: 추후 AuctionStatusService로 이동
-    @Transactional
-    public void fail(Auction auction) {
-        auction.fail();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/deal4u/fourplease/domain/member/mypage/controller/MyPageController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/member/mypage/controller/MyPageController.java
@@ -2,10 +2,12 @@ package com.deal4u.fourplease.domain.member.mypage.controller;
 
 import com.deal4u.fourplease.domain.common.PageResponse;
 import com.deal4u.fourplease.domain.member.entity.Member;
+import com.deal4u.fourplease.domain.member.mypage.dto.MemberInfoResponse;
 import com.deal4u.fourplease.domain.member.mypage.dto.MyPageAuctionHistory;
 import com.deal4u.fourplease.domain.member.mypage.dto.MyPageBidHistory;
 import com.deal4u.fourplease.domain.member.mypage.service.MyPageAuctionHistoryService;
 import com.deal4u.fourplease.domain.member.mypage.service.MyPageBidHistoryService;
+import com.deal4u.fourplease.domain.member.mypage.service.MyPageMemberInfoService;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +27,13 @@ public class MyPageController {
 
     private final MyPageBidHistoryService myPageBidHistoryService;
     private final MyPageAuctionHistoryService myPageAuctionHistoryService;
+    private final MyPageMemberInfoService myPageMemberInfoService;
 
 
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "마이페이지 입찰 내역 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @GetMapping("/bids")
@@ -40,10 +43,29 @@ public class MyPageController {
         return myPageBidHistoryService.getMyBidHistory(member, pageable);
     }
 
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "마이페이지 판매 내역 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @GetMapping("/auctions")
     public PageResponse<MyPageAuctionHistory> getMyAuctionHistory(
             @AuthenticationPrincipal Member member,
             @PageableDefault Pageable pageable) {
         return myPageAuctionHistoryService.getMyAuctionHistory(member, pageable);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "마이페이지 내 정보 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/member")
+    public MemberInfoResponse getMemberInfo(
+            @AuthenticationPrincipal Member member
+    ) {
+        return myPageMemberInfoService.getMemberInfo(member);
     }
 }

--- a/src/main/java/com/deal4u/fourplease/domain/member/mypage/dto/MemberInfoResponse.java
+++ b/src/main/java/com/deal4u/fourplease/domain/member/mypage/dto/MemberInfoResponse.java
@@ -1,0 +1,9 @@
+package com.deal4u.fourplease.domain.member.mypage.dto;
+
+public record MemberInfoResponse(
+        Integer totalReviews,
+        Double averageRating,
+        String nickname
+) {
+
+}

--- a/src/main/java/com/deal4u/fourplease/domain/member/mypage/service/MyPageMemberInfoService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/member/mypage/service/MyPageMemberInfoService.java
@@ -1,0 +1,32 @@
+package com.deal4u.fourplease.domain.member.mypage.service;
+
+import com.deal4u.fourplease.domain.member.entity.Member;
+import com.deal4u.fourplease.domain.member.mypage.dto.MemberInfoResponse;
+import com.deal4u.fourplease.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageMemberInfoService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMemberInfo(Member member) {
+
+        String sellerNickname = member.getNickName();
+
+        Integer totalReviews = reviewRepository.countBySellerMemberId(member.getMemberId());
+        Double averageRating = reviewRepository.getAverageRatingBySellerMemberId(
+                member.getMemberId());
+        averageRating = averageRating != null ? averageRating : 0.0;
+
+        return new MemberInfoResponse(
+                totalReviews,
+                averageRating,
+                sellerNickname
+        );
+    }
+}

--- a/src/test/java/com/deal4u/fourplease/domain/member/mypage/service/MyPageMemberInfoServiceTest.java
+++ b/src/test/java/com/deal4u/fourplease/domain/member/mypage/service/MyPageMemberInfoServiceTest.java
@@ -1,0 +1,90 @@
+package com.deal4u.fourplease.domain.member.mypage.service;
+
+import com.deal4u.fourplease.domain.member.entity.Member;
+import com.deal4u.fourplease.domain.member.mypage.dto.MemberInfoResponse;
+import com.deal4u.fourplease.domain.review.repository.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MyPageMemberInfoServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @InjectMocks
+    private MyPageMemberInfoService myPageMemberInfoService;
+
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = createTestMember(1L, "testNickname");
+    }
+
+    @Test
+    @DisplayName("회원 정보 조회 - 리뷰가 있는 경우")
+    void getMemberInfo_WithReviews_Success() {
+        // given
+        Long memberId = testMember.getMemberId();
+        Integer expectedTotalReviews = 5;
+        Double expectedAverageRating = 4.5;
+
+        given(reviewRepository.countBySellerMemberId(memberId))
+                .willReturn(expectedTotalReviews);
+        given(reviewRepository.getAverageRatingBySellerMemberId(memberId))
+                .willReturn(expectedAverageRating);
+
+        // when
+        MemberInfoResponse response = myPageMemberInfoService.getMemberInfo(testMember);
+
+        // then
+        assertThat(response.totalReviews()).isEqualTo(expectedTotalReviews);
+        assertThat(response.averageRating()).isEqualTo(expectedAverageRating);
+        assertThat(response.nickname()).isEqualTo("testNickname");
+
+        verify(reviewRepository).countBySellerMemberId(memberId);
+        verify(reviewRepository).getAverageRatingBySellerMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("회원 정보 조회 - 리뷰가 없는 경우")
+    void getMemberInfo_WithoutReviews_Success() {
+        // given
+        Long memberId = testMember.getMemberId();
+        Integer expectedTotalReviews = 0;
+        Double expectedAverageRating = null;
+
+        given(reviewRepository.countBySellerMemberId(memberId))
+                .willReturn(expectedTotalReviews);
+        given(reviewRepository.getAverageRatingBySellerMemberId(memberId))
+                .willReturn(expectedAverageRating);
+
+        // when
+        MemberInfoResponse response = myPageMemberInfoService.getMemberInfo(testMember);
+
+        // then
+        assertThat(response.totalReviews()).isEqualTo(expectedTotalReviews);
+        assertThat(response.averageRating()).isEqualTo(0.0);
+        assertThat(response.nickname()).isEqualTo("testNickname");
+
+        verify(reviewRepository).countBySellerMemberId(memberId);
+        verify(reviewRepository).getAverageRatingBySellerMemberId(memberId);
+    }
+
+    private Member createTestMember(Long memberId, String nickname) {
+        return Member.builder()
+                .memberId(memberId)
+                .nickName(nickname)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #97 

## 📝 작업 내용
- 마이페이지 내 정보 API 구현 및 테스트 코드 작성

```java
    @ResponseStatus(HttpStatus.OK)
    @ApiResponses(value = {
            @ApiResponse(responseCode = "200", description = "마이페이지 내 정보 조회 성공"),
            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰"),
            @ApiResponse(responseCode = "500", description = "서버 오류")
    })
    @GetMapping("/member")
    public MemberInfoResponse getMemberInfo(
            @AuthenticationPrincipal Member member
    ) {
        return myPageMemberInfoService.getMemberInfo(member);
    }
```

로그인한 유저를 기반으로 조회합니다.

## ✅ 피드백 반영사항
- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제)

## 📸 스크린샷 (선택)

<img width="848" height="107" alt="image" src="https://github.com/user-attachments/assets/bb058f83-406a-4ae7-93de-57303e03a71d" />

<img width="1273" height="516" alt="image" src="https://github.com/user-attachments/assets/01b347f8-da71-4962-bf7f-160f0f598fbb" />


## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?