### PR TITLE
fix(104): 전체 경매 조회 시 경매 상태가 'OPEN'인 것만 조회되도록 수정 - 정미광

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -54,7 +54,8 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
     @Query("SELECT a "
             + "FROM Auction a "
-            + "WHERE a.deleted = false")
+            + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN'")
     @EntityGraph(attributePaths = {"product", "product.category"})
     Page<Auction> findAll(Pageable pageable);
 
@@ -63,6 +64,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "JOIN a.product p "
             + "JOIN p.category c "
             + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN' "
             + "AND p.name LIKE %:keyword% "
             + "AND c.categoryId = :categoryId")
     @EntityGraph(attributePaths = {"product", "product.category"})
@@ -76,6 +78,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "FROM Auction a "
             + "JOIN a.product p "
             + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN' "
             + "AND p.name LIKE %:keyword%")
     @EntityGraph(attributePaths = {"product", "product.category"})
     Page<Auction> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
@@ -84,6 +87,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "FROM Auction a "
             + "JOIN a.product.category c "
             + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN' "
             + "AND c.categoryId = :categoryId")
     @EntityGraph(attributePaths = {"product", "product.category"})
     Page<Auction> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
@@ -93,6 +97,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "LEFT JOIN Bid b "
             + "ON b.auction = a "
             + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN' "
             + "GROUP BY a.auctionId "
             + "ORDER BY COUNT(b) DESC, "
             + "a.createdAt DESC")
@@ -106,6 +111,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "LEFT JOIN Bid b "
             + "ON b.auction = a "
             + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN' "
             + "AND p.name LIKE %:keyword% "
             + "AND c.categoryId = :categoryId "
             + "GROUP BY a.auctionId "
@@ -123,6 +129,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "LEFT JOIN Bid b "
             + "ON b.auction = a "
             + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN' "
             + "AND p.name LIKE %:keyword% "
             + "GROUP BY a.auctionId "
             + "ORDER BY COUNT(b) DESC")
@@ -135,6 +142,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             + "LEFT JOIN Bid b "
             + "ON b.auction = a "
             + "WHERE a.deleted = false "
+            + "AND a.status = 'OPEN' "
             + "AND c.categoryId = :categoryId "
             + "GROUP BY a.auctionId "
             + "ORDER BY COUNT(b) DESC")

--- a/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/deal4u/fourplease/domain/wishlist/controller/WishlistController.java
@@ -51,7 +51,6 @@ public class WishlistController {
             @Valid @RequestBody WishlistCreateRequest request,
             @AuthenticationPrincipal Member member
     ) {
-        // TODO: 병합 후 멤버 검증 validator로 변경 필요
         if (member == null) {
             throw ErrorCode.FORBIDDEN_RECEIVER.toException();
         }
@@ -70,7 +69,6 @@ public class WishlistController {
             @RequestParam(name = "order", defaultValue = "latest") String order,
             @AuthenticationPrincipal Member member
     ) {
-        // TODO: 병합 후 멤버 검증 validator로 변경 필요
         if (member == null) {
             throw ErrorCode.FORBIDDEN_RECEIVER.toException();
         }

--- a/src/test/java/com/deal4u/fourplease/testutil/TestUtils.java
+++ b/src/test/java/com/deal4u/fourplease/testutil/TestUtils.java
@@ -43,7 +43,6 @@ public class TestUtils {
     }
 
     public static Member genMember() {
-        // TODO: Member 추후 확인 필요
         return Member.builder()
                 .memberId(1L)
                 .email("user1@user.com")
@@ -55,7 +54,6 @@ public class TestUtils {
     }
 
     public static Member genMemberById(Long id) {
-        // TODO: Member 추후 확인 필요
         return Member.builder()
                 .memberId(id)
                 .email("user1@user.com")


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #104 

## 📝 작업 내용
- 전체 경매 조회 시 경매 상태가 'OPEN'인 것만 조회되도록 수정 


## 📸 스크린샷 (선택)
<img width="590" height="288" alt="스크린샷 2025-07-29 10 20 58" src="https://github.com/user-attachments/assets/1889aced-7bbc-4153-b597-c60a5814a193" />

<img width="585" height="286" alt="스크린샷 2025-07-29 10 34 16" src="https://github.com/user-attachments/assets/e7bd9c70-e301-4b7a-9538-831caf38d1c0" />


## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?