### PR TITLE
fix(108) : 판매자 판매 내역 COUNT 수정

### DIFF
--- a/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/repository/AuctionRepository.java
@@ -1,7 +1,6 @@
 package com.deal4u.fourplease.domain.auction.repository;
 
 import com.deal4u.fourplease.domain.auction.entity.Auction;
-import com.deal4u.fourplease.domain.auction.entity.AuctionStatus;
 import jakarta.persistence.Tuple;
 import java.util.List;
 import java.util.Optional;
@@ -153,10 +152,9 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
     );
 
     @Query("SELECT COUNT(a) FROM Auction a "
-            + "WHERE a.product.seller.member.memberId = :sellerId "
-            + "AND a.status = :status")
-    Integer countBySellerIdAndStatus(@Param("sellerId") Long sellerId,
-                                     @Param("status") AuctionStatus status);
+            + "WHERE a.deleted = false "
+            + "AND a.product.seller.member.memberId = :sellerId ")
+    Integer countBySellerId(@Param("sellerId") Long sellerId);
 
     @EntityGraph(attributePaths = {"product"})
     List<Auction> findByAuctionIdIn(List<Long> auctionIds);
@@ -177,5 +175,5 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
             ORDER BY a.createdAt DESC
             """)
     Page<Tuple> findAllAuctionHistoryByMemberId(@Param("memberId") Long memberId,
-                                                Pageable pageable);
+            Pageable pageable);
 }

--- a/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
+++ b/src/main/java/com/deal4u/fourplease/domain/auction/service/AuctionService.java
@@ -142,8 +142,7 @@ public class AuctionService {
         Double averageRating = reviewRepository.getAverageRatingBySellerMemberId(sellerId);
         averageRating = averageRating != null ? averageRating : 0.0;
 
-        Integer completedDeals =
-                auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE);
+        Integer completedDeals = auctionRepository.countBySellerId(sellerId);
 
         return new SellerInfoResponse(
                 sellerId,

--- a/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
+++ b/src/test/java/com/deal4u/fourplease/domain/auction/service/AuctionServiceTests.java
@@ -221,7 +221,6 @@ class AuctionServiceTests {
 
         when(auctionRepository.findByIdWithProduct(auctionId)).thenReturn(Optional.of(auction));
 
-
         assertThatThrownBy(() -> {
             auctionService.deleteByAuctionId(auctionId, genMemberById(2L));
         }).isInstanceOf(GlobalException.class).hasMessage("권한이 없습니다.");
@@ -243,9 +242,12 @@ class AuctionServiceTests {
         when(auctionRepository.findAllBySellerId(sellerId, pageable)).thenReturn(auctionPage);
 
         List<SellerSaleListResponse> responseList = List.of(
-                SellerSaleListResponse.toSellerSaleListResponse(auctionList.get(0), new BidSummaryDto(BigDecimal.valueOf(2000000), 5)),
-                SellerSaleListResponse.toSellerSaleListResponse(auctionList.get(1), new BidSummaryDto(BigDecimal.valueOf(10000000), 20)),
-                SellerSaleListResponse.toSellerSaleListResponse(auctionList.get(2), new BidSummaryDto(BigDecimal.valueOf(2000000), 20))
+                SellerSaleListResponse.toSellerSaleListResponse(auctionList.get(0),
+                        new BidSummaryDto(BigDecimal.valueOf(2000000), 5)),
+                SellerSaleListResponse.toSellerSaleListResponse(auctionList.get(1),
+                        new BidSummaryDto(BigDecimal.valueOf(10000000), 20)),
+                SellerSaleListResponse.toSellerSaleListResponse(auctionList.get(2),
+                        new BidSummaryDto(BigDecimal.valueOf(2000000), 20))
         );
         when(auctionSupportService.getSellerSaleListResponses(auctionPage))
                 .thenReturn(new PageImpl<>(responseList, pageable, responseList.size()));
@@ -422,7 +424,7 @@ class AuctionServiceTests {
         when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
         when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(
                 averageRating);
-        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE))
+        when(auctionRepository.countBySellerId(sellerId))
                 .thenReturn(completedDeals);
 
         // When
@@ -474,7 +476,7 @@ class AuctionServiceTests {
                 Optional.of(auction));
         when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
         when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(averageRating);
-        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE))
+        when(auctionRepository.countBySellerId(sellerId))
                 .thenReturn(completedDeals);
 
         // When
@@ -527,7 +529,7 @@ class AuctionServiceTests {
                 Optional.of(auction));
         when(reviewRepository.countBySellerMemberId(sellerId)).thenReturn(totalReviews);
         when(reviewRepository.getAverageRatingBySellerMemberId(sellerId)).thenReturn(averageRating);
-        when(auctionRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.CLOSE))
+        when(auctionRepository.countBySellerId(sellerId))
                 .thenReturn(completedDeals);
 
         // When
@@ -578,7 +580,8 @@ class AuctionServiceTests {
                 BigDecimal.valueOf(2000000L),
                 3
         );
-        List<String> productImageUrls = List.of("http://example.com/image1.jpg", "http://example.com/image2.jpg");
+        List<String> productImageUrls = List.of("http://example.com/image1.jpg",
+                "http://example.com/image2.jpg");
 
         ProductImageListResponse productImageListResponse = mock(ProductImageListResponse.class);
 
@@ -588,7 +591,8 @@ class AuctionServiceTests {
         when(productImageService.getByProduct(product)).thenReturn(productImageListResponse);
         when(productImageListResponse.toProductImageUrls()).thenReturn(productImageUrls);
 
-        when(wishlistRepository.findWishlist(auction, member.getMemberId())).thenReturn(Optional.of(wishlist));
+        when(wishlistRepository.findWishlist(auction, member.getMemberId())).thenReturn(
+                Optional.of(wishlist));
 
         // When
         AuctionDetailResponse actualResp = auctionService.getByAuctionId(auctionId, member);
@@ -612,7 +616,8 @@ class AuctionServiceTests {
                 BigDecimal.valueOf(2000000L),
                 3
         );
-        List<String> productImageUrls = List.of("http://example.com/image1.jpg", "http://example.com/image2.jpg");
+        List<String> productImageUrls = List.of("http://example.com/image1.jpg",
+                "http://example.com/image2.jpg");
         ProductImageListResponse productImageListResponse = mock(ProductImageListResponse.class);
 
         // Mocking 설정


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
- #108 

## 📝 작업 내용
- 판매 내역 COUNT와 실제 판매 내역의 개수가 일치하지 않는 문제

- 판매 내역 조회
```java
@Query("SELECT a "
            + "FROM Auction a "
            + "WHERE a.deleted = false "
            + "AND a.product.seller.member.memberId = :sellerId "
            + "ORDER BY a.createdAt DESC")
    @EntityGraph(attributePaths = {"product"})
    Page<Auction> findAllBySellerId(@Param("sellerId") Long sellerId, Pageable pageable);
```

- 판매 내역 COUNT
```java
@Query("SELECT COUNT(a) FROM Auction a "
            + "WHERE a.deleted = false "
            + "AND a.product.seller.member.memberId = :sellerId ")
    Integer countBySellerId(@Param("sellerId") Long sellerId);
```

기존의 AuctionStatus = `OPEN` 만을 COUNT하던 SQL을 판매 내역 조회와 일치하게 수정함.

## ✅ 피드백 반영사항
- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제)

## 📸 스크린샷 (선택)

<img width="849" height="580" alt="스크린샷 2025-07-29 21 05 35" src="https://github.com/user-attachments/assets/6a7ea4ec-c6ad-4081-b6c7-4392328bc18b" />

<img width="849" height="580" alt="스크린샷 2025-07-29 21 05 35" src="https://github.com/user-attachments/assets/d8b67d4d-2e5b-4c64-abb2-be923f7e20b6" />

<img width="851" height="291" alt="스크린샷 2025-07-29 21 11 19" src="https://github.com/user-attachments/assets/359b1758-ca0b-48a3-8621-545f40958383" />

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?